### PR TITLE
refactor: update button handling methods for clarity

### DIFF
--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Dolphin.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Dolphin.kt
@@ -7,6 +7,8 @@ import com.acmerobotics.roadrunner.Vector2d
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp
 import com.qualcomm.robotcore.hardware.HardwareMap
 import dev.kingssack.volt.manual.SimpleManualModeWithSpeedModes
+import dev.kingssack.volt.util.GamepadAnalogInput
+import dev.kingssack.volt.util.GamepadButton
 import org.firstinspires.ftc.teamcode.attachment.Lift
 import org.firstinspires.ftc.teamcode.attachment.Wrist
 import org.firstinspires.ftc.teamcode.robot.Steve
@@ -45,51 +47,47 @@ class Dolphin : SimpleManualModeWithSpeedModes<Steve>() {
         ))
     }
 
-    private val quickTurnTowardBaskets = Interaction({ isButtonTapped("dpad_left1") },
+    private val quickTurnTowardBaskets = Interaction({ isButtonTapped(GamepadButton.DPAD_LEFT1) },
         { robot.turnTo(Math.toRadians(45.0)) })
-    private val quickTurnTowardSubmersible = Interaction({ isButtonTapped("dpad_up1") },
+    private val quickTurnTowardSubmersible = Interaction({ isButtonTapped(GamepadButton.DPAD_UP1) },
         { robot.turnTo(Math.toRadians(-90.0)) })
-    private val quickDepositSpecimen = Interaction({ isButtonTapped("dpad_right1") },
+    private val quickDepositSpecimen = Interaction({ isButtonTapped(GamepadButton.DPAD_RIGHT1) },
         { robot.depositSpecimen(Lift.upperSubmersibleBarHeight) })
 
     private val controlLift = Interaction({ true },
-        { InstantAction { robot.lift.currentGoal += -getAnalogValue("left_stick_y2").toInt() * LIFT_MULTIPLIER } })
-    /* private val resetLift = Interaction({ isButtonTapped("left_stick_button") },
-        { InstantAction { robot.lift.reset() } }) */
+        { InstantAction { robot.lift.currentGoal += -getAnalogValue(GamepadAnalogInput.LEFT_STICK_Y2).toInt() * LIFT_MULTIPLIER } })
 
-    private val openClaw = Interaction({ isButtonTapped("a2") }, { robot.claw.open() })
-    private val closeClaw = Interaction({ isButtonTapped("b2") }, { robot.claw.close() })
+    private val openClaw = Interaction({ isButtonTapped(GamepadButton.A2) }, { robot.claw.open() })
+    private val closeClaw = Interaction({ isButtonTapped(GamepadButton.B2) }, { robot.claw.close() })
 
-    private val centerWrist = Interaction({ isButtonTapped("dpad_down2") }, { robot.wrist.goTo(Wrist.centerPosition) })
-    private val rotateWristLeft = Interaction({ isButtonPressed("dpad_left2") },
+    private val centerWrist = Interaction({ isButtonTapped(GamepadButton.DPAD_DOWN2) }, { robot.wrist.goTo(Wrist.centerPosition) })
+    private val rotateWristLeft = Interaction({ isButtonPressed(GamepadButton.DPAD_LEFT2) },
         { robot.wrist.goTo(robot.wrist.getPosition() + 0.005) })
-    private val rotateWristRight = Interaction({ isButtonPressed("dpad_right2") },
+    private val rotateWristRight = Interaction({ isButtonPressed(GamepadButton.DPAD_RIGHT2) },
         { robot.wrist.goTo(robot.wrist.getPosition() - 0.005) })
 
-    private val toggleShoulder = ToggleInteraction({ isButtonTapped("y2") },
+    private val toggleShoulder = ToggleInteraction({ isButtonTapped(GamepadButton.Y2) },
         { robot.shoulder.extend() }, { robot.shoulder.retract() })
 
     private val controlElbow = Interaction({ true },
-        { InstantAction { robot.elbow.setPower(-getAnalogValue("right_stick_y2")) } })
-    private val extendElbow = Interaction({ isButtonTapped("right_stick_button2") }, { robot.elbow.extend() })
+        { InstantAction { robot.elbow.setPower(-getAnalogValue(GamepadAnalogInput.RIGHT_STICK_Y2)) } })
+    private val extendElbow = Interaction({ isButtonTapped(GamepadButton.RIGHT_STICK_BUTTON2) }, { robot.elbow.extend() })
 
-    private val extendArm = Interaction({ isButtonTapped("dpad_up2") }, { robot.extendArm() })
+    private val extendArm = Interaction({ isButtonTapped(GamepadButton.DPAD_UP2) }, { robot.extendArm() })
 
-    private val extendTail = ToggleInteraction({ isButtonTapped("left_bumper2") }, { robot.tail.extend() }, { robot.tail.center() })
-    private val retractTail = ToggleInteraction({ isButtonTapped("right_bumper2") }, { robot.tail.retract() }, { robot.tail.center() })
+    private val extendTail = ToggleInteraction({ isButtonTapped(GamepadButton.LEFT_BUMPER2) }, { robot.tail.extend() }, { robot.tail.center() })
+    private val retractTail = ToggleInteraction({ isButtonTapped(GamepadButton.RIGHT_BUMPER2) }, { robot.tail.retract() }, { robot.tail.center() })
 
-    private val toggleIntake = ToggleInteraction({ isButtonTapped("x2") },
+    private val toggleIntake = ToggleInteraction({ isButtonTapped(GamepadButton.X2) },
         { robot.intake.enableIntake() }, { robot.intake.reverseIntake() })
-    private val disableIntake = Interaction({ isButtonHeld("x2", 200.0) }, { robot.intake.disableIntake() })
+    private val disableIntake = Interaction({ isButtonHeld(GamepadButton.X2, 200.0) }, { robot.intake.disableIntake() })
 
     init {
         interactions.addAll(listOf(
             quickTurnTowardBaskets,
             quickTurnTowardSubmersible,
             quickDepositSpecimen,
-            // quickRetrieveSpecimen,
             controlLift,
-            // resetLift,
             openClaw,
             closeClaw,
             centerWrist,

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Whale.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Whale.kt
@@ -7,6 +7,8 @@ import com.acmerobotics.roadrunner.Vector2d
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp
 import com.qualcomm.robotcore.hardware.HardwareMap
 import dev.kingssack.volt.manual.SimpleManualModeWithSpeedModes
+import dev.kingssack.volt.util.GamepadAnalogInput
+import dev.kingssack.volt.util.GamepadButton
 import org.firstinspires.ftc.teamcode.attachment.Lift
 import org.firstinspires.ftc.teamcode.attachment.Wrist
 import org.firstinspires.ftc.teamcode.robot.Steve
@@ -45,34 +47,31 @@ class Whale : SimpleManualModeWithSpeedModes<Steve>() {
         ))
     }
 
-    private val quickTurnTowardBaskets = Interaction({ isButtonTapped("dpad_left1") },
+    private val quickTurnTowardBaskets = Interaction({ isButtonTapped(GamepadButton.DPAD_LEFT1) },
         { robot.turnTo(Math.toRadians(45.0)) })
-    private val quickTurnTowardSubmersible = Interaction({ isButtonTapped("dpad_up1") },
-        { robot.turnTo(Math.toRadians(-90.0)) })
-    private val quickDepositSample = Interaction(({ isButtonTapped("dpad_right1") }),
+    private val quickTurnTowardSubmersible = Interaction({ isButtonTapped(GamepadButton.DPAD_UP1) }, { robot.turnTo(Math.toRadians(-90.0)) })
+    private val quickDepositSample = Interaction({ isButtonTapped(GamepadButton.DPAD_RIGHT1) },
         { robot.depositSample(Lift.upperBasketHeight) })
 
-    private val raiseLift = Interaction({ isButtonTapped("right_bumper2") }, { robot.lift.goTo(Lift.upperBasketHeight) })
-    private val lowerLift = Interaction({ isButtonTapped("left_bumper2") }, { robot.lift.drop() })
+    private val raiseLift = Interaction({ isButtonTapped(GamepadButton.RIGHT_BUMPER2) }, { robot.lift.goTo(Lift.upperBasketHeight) })
+    private val lowerLift = Interaction({ isButtonTapped(GamepadButton.LEFT_BUMPER2) }, { robot.lift.drop() })
     private val controlLift = Interaction({ true },
-        { InstantAction { robot.lift.currentGoal += -getAnalogValue("left_stick_y2").toInt() * LIFT_MULTIPLIER } })
-    /* private val resetLift = Interaction({ isButtonTapped("left_stick_button") },
-        { InstantAction { robot.lift.reset() } }) */
+        { InstantAction { robot.lift.currentGoal += -getAnalogValue(GamepadAnalogInput.LEFT_STICK_Y2).toInt() * LIFT_MULTIPLIER } })
 
-    private val openClaw = Interaction({ isButtonTapped("a2") }, { robot.claw.open() })
-    private val closeClaw = Interaction({ isButtonTapped("b2") }, { robot.claw.close() })
+    private val openClaw = Interaction({ isButtonTapped(GamepadButton.A2) }, { robot.claw.open() })
+    private val closeClaw = Interaction({ isButtonTapped(GamepadButton.B2) }, { robot.claw.close() })
 
-    private val centerWrist = Interaction({ isButtonTapped("dpad_down2") }, { robot.wrist.goTo(Wrist.centerPosition) })
-    private val rotateWristLeft = Interaction({ isButtonPressed("dpad_left2") },
+    private val centerWrist = Interaction({ isButtonTapped(GamepadButton.DPAD_DOWN2) }, { robot.wrist.goTo(Wrist.centerPosition) })
+    private val rotateWristLeft = Interaction({ isButtonPressed(GamepadButton.DPAD_LEFT2) },
         { robot.wrist.goTo(robot.wrist.getPosition() + 0.005) })
-    private val rotateWristRight = Interaction({ isButtonPressed("dpad_right2") },
+    private val rotateWristRight = Interaction({ isButtonPressed(GamepadButton.DPAD_RIGHT2) },
         { robot.wrist.goTo(robot.wrist.getPosition() - 0.005) })
 
-    private val extendArm = Interaction({ isButtonTapped("x2") }, { robot.extendArm() })
-    private val retractArm = Interaction({ isButtonTapped("y2") }, { robot.retractArm() })
+    private val extendArm = Interaction({ isButtonTapped(GamepadButton.X2) }, { robot.extendArm() })
+    private val retractArm = Interaction({ isButtonTapped(GamepadButton.Y2) }, { robot.retractArm() })
 
     private val controlElbow = Interaction({ true },
-        { InstantAction { robot.elbow.setPower(-getAnalogValue("right_stick_y2")) } })
+        { InstantAction { robot.elbow.setPower(-getAnalogValue(GamepadAnalogInput.RIGHT_STICK_Y2)) } })
 
     init {
         interactions.addAll(listOf(
@@ -82,7 +81,6 @@ class Whale : SimpleManualModeWithSpeedModes<Steve>() {
             raiseLift,
             lowerLift,
             controlLift,
-            // resetLift,
             openClaw,
             closeClaw,
             centerWrist,

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Steve.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Steve.kt
@@ -10,10 +10,9 @@ import com.qualcomm.robotcore.hardware.*
 import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit
 import org.firstinspires.ftc.teamcode.attachment.*
-import org.firstinspires.ftc.teamcode.util.FieldParams
 
 /**
- * Steve is a robot for the 2024-2025 INTO THE DEEP FTC Season.
+ * Steve is a robot for the 2024-2025 INTOTHEDEEP FTC Season.
  *
  * Steve can collect samples, deposit samples, detect objects, and detect distances.
  * Steve has a lift, claw, shoulder, wrist, intake, two distance sensors, and HuskyLens.

--- a/Volt/src/main/kotlin/dev/kingssack/volt/autonomous/AutonomousMode.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/autonomous/AutonomousMode.kt
@@ -10,23 +10,30 @@ import dev.kingssack.volt.robot.Robot
 
 /**
  * AutonomousMode is an abstract class that defines the methods for running an autonomous mode.
+ *
+ * @property robot the robot instance
  */
 abstract class AutonomousMode<R : Robot> : LinearOpMode() {
     protected lateinit var robot : R
         private set
 
+    /**
+     * Create the robot instance.
+     *
+     * @param hardwareMap the hardware map for the robot
+     */
     abstract fun createRobot(hardwareMap: HardwareMap): R
-
-    private val dash: FtcDashboard? = FtcDashboard.getInstance()
-    private val canvas = Canvas()
-
-    protected val actionSequence = mutableListOf<() -> Action>()
 
     override fun runOpMode() {
         robot = createRobot(hardwareMap)
         waitForStart()
         execute()
     }
+
+    private val dash: FtcDashboard? = FtcDashboard.getInstance()
+    private val canvas = Canvas()
+
+    protected val actionSequence = mutableListOf<() -> Action>()
 
     /**
      * Execute the autonomous sequence.

--- a/Volt/src/main/kotlin/dev/kingssack/volt/util/Buttons.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/util/Buttons.kt
@@ -1,0 +1,33 @@
+package dev.kingssack.volt.util
+
+/**
+ * Represents buttons on a gamepad.
+ * Includes buttons from both gamepad1 and gamepad2.
+ */
+enum class GamepadButton {
+    A1, B1, X1, Y1,
+    LEFT_BUMPER1, RIGHT_BUMPER1,
+    LEFT_STICK_BUTTON1, RIGHT_STICK_BUTTON1,
+    DPAD_UP1, DPAD_DOWN1, DPAD_LEFT1, DPAD_RIGHT1,
+    BACK1, START1, GUIDE1,
+
+    A2, B2, X2, Y2,
+    LEFT_BUMPER2, RIGHT_BUMPER2,
+    LEFT_STICK_BUTTON2, RIGHT_STICK_BUTTON2,
+    DPAD_UP2, DPAD_DOWN2, DPAD_LEFT2, DPAD_RIGHT2,
+    BACK2, START2, GUIDE2
+}
+
+/**
+ * Represents analog inputs on a gamepad.
+ * Includes inputs from both gamepad1 and gamepad2.
+ */
+enum class GamepadAnalogInput {
+    LEFT_STICK_X1, LEFT_STICK_Y1,
+    RIGHT_STICK_X1, RIGHT_STICK_Y1,
+    LEFT_TRIGGER1, RIGHT_TRIGGER1,
+
+    LEFT_STICK_X2, LEFT_STICK_Y2,
+    RIGHT_STICK_X2, RIGHT_STICK_Y2,
+    LEFT_TRIGGER2, RIGHT_TRIGGER2
+}


### PR DESCRIPTION
Refactor button handling methods in ManualMode to use 
GamepadButton enum instead of String for better type safety 
and clarity. Update method parameters and documentation 
to reflect this change. Add new method to get raw analog 
values from GamepadAnalogInput for improved functionality.