### PR TITLE
Update to Volt 0.3.3

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pp/Constants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pp/Constants.java
@@ -35,7 +35,7 @@ public class Constants {
                     .robotWidth(13)
                     .robotLength(9)
                     .forwardTicksToInches(0.0057725)
-                    .strafeTicksToInches(0.0062025)
+                    .strafeTicksToInches(0.004527)
                     .turnTicksToInches(0.0092964);
 
     public static PathConstraints pathConstraints = new PathConstraints(

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/attachment/Classifier.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/attachment/Classifier.kt
@@ -8,7 +8,7 @@ import dev.kingssack.volt.attachment.ServoAttachment
 /**
  * [Classifier] is a [ServoAttachment] that controls a [gate] used for launching artifacts.
  */
-class Classifier(gate: Servo) : Attachment("classifier") {
+class Classifier(gate: Servo) : Attachment("Classifier") {
     fun rotateToNextArtifact(): Action = action {
         loop { true }
     }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/attachment/Launcher.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/attachment/Launcher.kt
@@ -12,7 +12,7 @@ import dev.kingssack.volt.attachment.Attachment
  * @param rightMotor the right [DcMotor] of the [Launcher]
  */
 class Launcher(private val leftMotor: DcMotor, private val rightMotor: DcMotor) :
-    Attachment("launcher") {
+    Attachment("Launcher") {
     init {
         leftMotor.direction = DcMotorSimple.Direction.FORWARD
         rightMotor.direction = DcMotorSimple.Direction.REVERSE
@@ -34,6 +34,15 @@ class Launcher(private val leftMotor: DcMotor, private val rightMotor: DcMotor) 
         init {
             leftMotor.power = 0.0
             rightMotor.power = 0.0
+        }
+
+        loop { true }
+    }
+
+    fun setPower(power: Double): Action = action {
+        init {
+            leftMotor.power = power
+            rightMotor.power = power
         }
 
         loop { true }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/attachment/Launcher.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/attachment/Launcher.kt
@@ -39,12 +39,8 @@ class Launcher(private val leftMotor: DcMotor, private val rightMotor: DcMotor) 
         loop { true }
     }
 
-    fun setPower(power: Double): Action = action {
-        init {
-            leftMotor.power = power
-            rightMotor.power = power
-        }
-
-        loop { true }
+    fun setPower(power: Double) {
+        leftMotor.power = power
+        rightMotor.power = power
     }
 }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/attachment/Storage.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/attachment/Storage.kt
@@ -1,0 +1,11 @@
+package org.firstinspires.ftc.teamcode.attachment
+
+import com.acmerobotics.roadrunner.Action
+import com.qualcomm.robotcore.hardware.Servo
+import dev.kingssack.volt.attachment.ServoAttachment
+import dev.kingssack.volt.util.ServoPosition
+
+class Storage(servo: Servo) : ServoAttachment("Storage", servo) {
+    fun release(): Action = goTo(ServoPosition(0.0))
+    fun close(): Action = goTo(ServoPosition(1.0))
+}

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/attachment/Storage.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/attachment/Storage.kt
@@ -6,6 +6,6 @@ import dev.kingssack.volt.attachment.ServoAttachment
 import dev.kingssack.volt.util.ServoPosition
 
 class Storage(servo: Servo) : ServoAttachment("Storage", servo) {
-    fun release(): Action = goTo(ServoPosition(0.0))
-    fun close(): Action = goTo(ServoPosition(1.0))
+    fun release(): Action = goTo(ServoPosition(1.0))
+    fun close(): Action = goTo(ServoPosition(0.0))
 }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/autonomous/Magpie.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/autonomous/Magpie.kt
@@ -4,7 +4,7 @@ import com.acmerobotics.dashboard.config.Config
 import com.pedropathing.geometry.Pose
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous
 import dev.kingssack.volt.opmode.autonomous.AutonomousMode
-import org.firstinspires.ftc.teamcode.robot.Jones
+import org.firstinspires.ftc.teamcode.robot.JonesPP
 import org.firstinspires.ftc.teamcode.util.AllianceColor
 import org.firstinspires.ftc.teamcode.util.PathConstants
 import org.firstinspires.ftc.teamcode.util.toRadians
@@ -12,8 +12,8 @@ import org.firstinspires.ftc.teamcode.util.toRadians
 @Config
 @Autonomous(name = "Magpie", group = "Competition")
 class Magpie :
-    AutonomousMode<Jones>({ hardwareMap ->
-        Jones(hardwareMap, Pose(INITIAL_X, INITIAL_Y, INITIAL_HEADING.toRadians()).mirror())
+    AutonomousMode<JonesPP>({ hardwareMap ->
+        JonesPP(hardwareMap, Pose(INITIAL_X, INITIAL_Y, INITIAL_HEADING.toRadians()).mirror())
     }) {
     companion object {
         @JvmField var INITIAL_X: Double = 56.0

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/autonomous/Magpie.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/autonomous/Magpie.kt
@@ -12,11 +12,9 @@ import org.firstinspires.ftc.teamcode.util.toRadians
 @Config
 @Autonomous(name = "Magpie", group = "Competition")
 class Magpie :
-    AutonomousMode<Jones>(
-        robotFactory = { hardwareMap ->
-            Jones(hardwareMap, Pose(INITIAL_X, INITIAL_Y, INITIAL_HEADING.toRadians()).mirror())
-        }
-    ) {
+    AutonomousMode<Jones>({ hardwareMap ->
+        Jones(hardwareMap, Pose(INITIAL_X, INITIAL_Y, INITIAL_HEADING.toRadians()).mirror())
+    }) {
     companion object {
         @JvmField var INITIAL_X: Double = 56.0
         @JvmField var INITIAL_Y: Double = 8.0
@@ -25,7 +23,5 @@ class Magpie :
 
     private val paths by lazy { PathConstants(robot.drivetrain.follower, AllianceColor.BLUE) }
 
-    override fun sequence() = execute {
-        +robot.drivetrain.pathTo(paths.pathToLoadingZone)
-    }
+    override fun sequence() = execute { +robot.drivetrain.pathTo(paths.pathToLoadingZone) }
 }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/autonomous/Pigeon.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/autonomous/Pigeon.kt
@@ -11,7 +11,7 @@ import org.firstinspires.ftc.teamcode.util.toRadians
 class Pigeon :
     AutonomousMode<Gabe>({ hardwareMap -> Gabe(hardwareMap, Pose2d(Vector2d(0.0, 0.0), 0.0)) }) {
     override fun sequence() = execute {
-        robot.drivetrain.trajectory {
+        +robot.drivetrain.trajectory {
             strafeTo(Vector2d(0.0, 0.0))
             strafeToLinearHeading(Vector2d(48.0, 0.0), 0.0.toRadians())
         }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/autonomous/Pigeon.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/autonomous/Pigeon.kt
@@ -4,16 +4,26 @@ import com.acmerobotics.roadrunner.Pose2d
 import com.acmerobotics.roadrunner.Vector2d
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous
 import dev.kingssack.volt.opmode.autonomous.AutonomousMode
-import org.firstinspires.ftc.teamcode.robot.Gabe
+import org.firstinspires.ftc.teamcode.robot.GabeRR
+import org.firstinspires.ftc.teamcode.robot.launcher
+import org.firstinspires.ftc.teamcode.robot.storage
 import org.firstinspires.ftc.teamcode.util.toRadians
 
 @Autonomous(name = "Pigeon", group = "Competition")
 class Pigeon :
-    AutonomousMode<Gabe>({ hardwareMap -> Gabe(hardwareMap, Pose2d(Vector2d(0.0, 0.0), 0.0)) }) {
+    AutonomousMode<GabeRR>({ hardwareMap ->
+        GabeRR(hardwareMap, Pose2d(Vector2d(0.0, 0.0), 0.0))
+    }) {
     override fun sequence() = execute {
         +robot.drivetrain.trajectory {
             strafeTo(Vector2d(0.0, 0.0))
             strafeToLinearHeading(Vector2d(48.0, 0.0), 0.0.toRadians())
+        }
+
+        sequence {
+            launcher { enable() }
+            storage { release() }
+            launcher { disable() }
         }
     }
 }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/autonomous/Pigeon.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/autonomous/Pigeon.kt
@@ -9,9 +9,7 @@ import org.firstinspires.ftc.teamcode.util.toRadians
 
 @Autonomous(name = "Pigeon", group = "Competition")
 class Pigeon :
-    AutonomousMode<Gabe>(
-        robotFactory = { hardwareMap -> Gabe(hardwareMap, Pose2d(Vector2d(0.0, 0.0), 0.0)) }
-    ) {
+    AutonomousMode<Gabe>({ hardwareMap -> Gabe(hardwareMap, Pose2d(Vector2d(0.0, 0.0), 0.0)) }) {
     override fun sequence() = execute {
         robot.drivetrain.trajectory {
             strafeTo(Vector2d(0.0, 0.0))

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Manatee.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Manatee.kt
@@ -2,32 +2,29 @@ package org.firstinspires.ftc.teamcode.opmode.manual
 
 import com.acmerobotics.dashboard.config.Config
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp
+import dev.kingssack.volt.attachment.drivetrain.MecanumDriveWithRR
 import dev.kingssack.volt.opmode.manual.SimpleManualModeWithSpeedModes
 import dev.kingssack.volt.util.GamepadAnalogInput
 import dev.kingssack.volt.util.GamepadButton
-import org.firstinspires.ftc.robotcore.external.Telemetry
-import org.firstinspires.ftc.teamcode.robot.Gabe
+import org.firstinspires.ftc.teamcode.robot.GabeRR
 
 @Config
 @TeleOp(name = "Manatee", group = "Competition")
-class Manatee : SimpleManualModeWithSpeedModes<Gabe>({ hardwareMap -> Gabe(hardwareMap) }) {
+class Manatee :
+    SimpleManualModeWithSpeedModes<MecanumDriveWithRR, GabeRR>({ hardwareMap ->
+        GabeRR(hardwareMap)
+    }) {
     init {
-        onButtonPressed(GamepadButton.RIGHT_BUMPER2) { +robot.launcher.enable() }
+        onButtonTapped(GamepadButton.RIGHT_BUMPER2) { +robot.launcher.enable() }
         onButtonReleased(GamepadButton.RIGHT_BUMPER2) { +robot.launcher.disable() }
 
         onButtonReleased(GamepadButton.A2) { +robot.storage.release() }
         onButtonReleased(GamepadButton.B2) { +robot.storage.close() }
 
-        onAnalogValueChanged(GamepadAnalogInput.RIGHT_TRIGGER2) { value ->
+        onAnalog(GamepadAnalogInput.RIGHT_TRIGGER2) { value ->
             if (!isButtonPressed(GamepadButton.RIGHT_BUMPER2)) {
-                +robot.launcher.setPower(value)
+                robot.launcher.setPower(value.toDouble())
             }
         }
-    }
-
-    context(telemetry: Telemetry)
-    override fun tick() {
-        robot.drivetrain.setDrivePowers(calculatePoseWithGamepad())
-        super.tick()
     }
 }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Manatee.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Manatee.kt
@@ -5,19 +5,14 @@ import com.qualcomm.robotcore.eventloop.opmode.TeleOp
 import dev.kingssack.volt.opmode.manual.SimpleManualModeWithSpeedModes
 import dev.kingssack.volt.util.GamepadButton
 import org.firstinspires.ftc.robotcore.external.Telemetry
-import org.firstinspires.ftc.teamcode.robot.Jones
+import org.firstinspires.ftc.teamcode.robot.Gabe
 
 @Config
 @TeleOp(name = "Manatee", group = "Default")
-class Manatee :
-    SimpleManualModeWithSpeedModes<Jones>(robotFactory = { hardwareMap -> Jones(hardwareMap) }) {
+class Manatee : SimpleManualModeWithSpeedModes<Gabe>({ hardwareMap -> Gabe(hardwareMap) }) {
     init {
         onButtonPressed(GamepadButton.RIGHT_BUMPER2) { +robot.launcher.enable() }
         onButtonReleased(GamepadButton.RIGHT_BUMPER2) { +robot.launcher.disable() }
-    }
-
-    override fun initialize() {
-        robot.drivetrain.startTeleOpDrive()
     }
 
     context(telemetry: Telemetry)

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Manatee.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Manatee.kt
@@ -8,11 +8,14 @@ import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.teamcode.robot.Gabe
 
 @Config
-@TeleOp(name = "Manatee", group = "Default")
+@TeleOp(name = "Manatee", group = "Competition")
 class Manatee : SimpleManualModeWithSpeedModes<Gabe>({ hardwareMap -> Gabe(hardwareMap) }) {
     init {
         onButtonPressed(GamepadButton.RIGHT_BUMPER2) { +robot.launcher.enable() }
         onButtonReleased(GamepadButton.RIGHT_BUMPER2) { +robot.launcher.disable() }
+
+        onButtonPressed(GamepadButton.A2) { +robot.storage.release() }
+        onButtonReleased(GamepadButton.A2) { +robot.storage.close() }
     }
 
     context(telemetry: Telemetry)

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Manatee.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Manatee.kt
@@ -18,8 +18,8 @@ class Manatee :
         onButtonTapped(GamepadButton.RIGHT_BUMPER2) { +robot.launcher.enable() }
         onButtonReleased(GamepadButton.RIGHT_BUMPER2) { +robot.launcher.disable() }
 
-        onButtonReleased(GamepadButton.A2) { +robot.storage.release() }
-        onButtonReleased(GamepadButton.B2) { +robot.storage.close() }
+        onButtonTapped(GamepadButton.A2) { +robot.storage.release() }
+        onButtonReleased(GamepadButton.A2) { +robot.storage.close() }
 
         onAnalog(GamepadAnalogInput.RIGHT_TRIGGER2) { value ->
             if (!isButtonPressed(GamepadButton.RIGHT_BUMPER2)) {

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Manatee.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Manatee.kt
@@ -3,6 +3,7 @@ package org.firstinspires.ftc.teamcode.opmode.manual
 import com.acmerobotics.dashboard.config.Config
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp
 import dev.kingssack.volt.opmode.manual.SimpleManualModeWithSpeedModes
+import dev.kingssack.volt.util.GamepadAnalogInput
 import dev.kingssack.volt.util.GamepadButton
 import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.teamcode.robot.Gabe
@@ -14,8 +15,14 @@ class Manatee : SimpleManualModeWithSpeedModes<Gabe>({ hardwareMap -> Gabe(hardw
         onButtonPressed(GamepadButton.RIGHT_BUMPER2) { +robot.launcher.enable() }
         onButtonReleased(GamepadButton.RIGHT_BUMPER2) { +robot.launcher.disable() }
 
-        onButtonPressed(GamepadButton.A2) { +robot.storage.release() }
-        onButtonReleased(GamepadButton.A2) { +robot.storage.close() }
+        onButtonReleased(GamepadButton.A2) { +robot.storage.release() }
+        onButtonReleased(GamepadButton.B2) { +robot.storage.close() }
+
+        onAnalogValueChanged(GamepadAnalogInput.RIGHT_TRIGGER2) { value ->
+            if (!isButtonPressed(GamepadButton.RIGHT_BUMPER2)) {
+                +robot.launcher.setPower(value)
+            }
+        }
     }
 
     context(telemetry: Telemetry)

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Narwhal.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Narwhal.kt
@@ -1,10 +1,12 @@
 package org.firstinspires.ftc.teamcode.opmode.manual
 
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp
 import dev.kingssack.volt.opmode.manual.SimpleManualModeWithSpeedModes
 import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.teamcode.robot.Jones
 
-class Penguin : SimpleManualModeWithSpeedModes<Jones>({ hardwareMap -> Jones(hardwareMap) }) {
+@TeleOp(name = "Narwhal", group = "Default")
+class Narwhal : SimpleManualModeWithSpeedModes<Jones>({ hardwareMap -> Jones(hardwareMap) }) {
     init {
         // Add any button bindings or initialization code here if needed
     }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Narwhal.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Narwhal.kt
@@ -3,10 +3,10 @@ package org.firstinspires.ftc.teamcode.opmode.manual
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp
 import dev.kingssack.volt.opmode.manual.SimpleManualModeWithSpeedModes
 import org.firstinspires.ftc.robotcore.external.Telemetry
-import org.firstinspires.ftc.teamcode.robot.Jones
+import org.firstinspires.ftc.teamcode.robot.JonesPP
 
 @TeleOp(name = "Narwhal", group = "Default")
-class Narwhal : SimpleManualModeWithSpeedModes<Jones>({ hardwareMap -> Jones(hardwareMap) }) {
+class Narwhal : SimpleManualModeWithSpeedModes<JonesPP>({ hardwareMap -> JonesPP(hardwareMap) }) {
     init {
         // Add any button bindings or initialization code here if needed
     }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Narwhal.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Narwhal.kt
@@ -1,23 +1,16 @@
 package org.firstinspires.ftc.teamcode.opmode.manual
 
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp
+import dev.kingssack.volt.attachment.drivetrain.MecanumDriveWithPP
 import dev.kingssack.volt.opmode.manual.SimpleManualModeWithSpeedModes
-import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.teamcode.robot.JonesPP
 
 @TeleOp(name = "Narwhal", group = "Default")
-class Narwhal : SimpleManualModeWithSpeedModes<JonesPP>({ hardwareMap -> JonesPP(hardwareMap) }) {
-    init {
-        // Add any button bindings or initialization code here if needed
-    }
-
+class Narwhal :
+    SimpleManualModeWithSpeedModes<MecanumDriveWithPP, JonesPP>({ hardwareMap ->
+        JonesPP(hardwareMap)
+    }) {
     override fun initialize() {
         robot.drivetrain.startTeleOpDrive()
-    }
-
-    context(telemetry: Telemetry)
-    override fun tick() {
-        robot.drivetrain.setDrivePowers(calculatePoseWithGamepad())
-        super.tick()
     }
 }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Penguin.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/opmode/manual/Penguin.kt
@@ -1,0 +1,21 @@
+package org.firstinspires.ftc.teamcode.opmode.manual
+
+import dev.kingssack.volt.opmode.manual.SimpleManualModeWithSpeedModes
+import org.firstinspires.ftc.robotcore.external.Telemetry
+import org.firstinspires.ftc.teamcode.robot.Jones
+
+class Penguin : SimpleManualModeWithSpeedModes<Jones>({ hardwareMap -> Jones(hardwareMap) }) {
+    init {
+        // Add any button bindings or initialization code here if needed
+    }
+
+    override fun initialize() {
+        robot.drivetrain.startTeleOpDrive()
+    }
+
+    context(telemetry: Telemetry)
+    override fun tick() {
+        robot.drivetrain.setDrivePowers(calculatePoseWithGamepad())
+        super.tick()
+    }
+}

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Gabe.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Gabe.kt
@@ -67,7 +67,7 @@ abstract class Gabe<T : MecanumDrivetrain>(hardwareMap: HardwareMap, drivetrain:
 
 @VoltBuilderDsl
 inline fun <D : MecanumDrivetrain, T : Gabe<D>> VoltActionBuilder<T>.launcher(block: Launcher.() -> Action) {
-    block(robot.launcher)
+    +block(robot.launcher)
 }
 
 @VoltBuilderDsl

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Gabe.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Gabe.kt
@@ -3,13 +3,13 @@ package org.firstinspires.ftc.teamcode.robot
 import com.acmerobotics.dashboard.config.Config
 import com.acmerobotics.roadrunner.*
 import com.qualcomm.hardware.dfrobot.HuskyLens
-import com.qualcomm.hardware.dfrobot.HuskyLens.Block
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot.LogoFacingDirection
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot.UsbFacingDirection
 import com.qualcomm.robotcore.hardware.*
-import dev.kingssack.volt.drivetrain.SimpleMecanumDriveWithRR
+import dev.kingssack.volt.drivetrain.MecanumDriveWithRR
 import dev.kingssack.volt.robot.Robot
 import org.firstinspires.ftc.robotcore.external.Telemetry
+import org.firstinspires.ftc.teamcode.attachment.Launcher
 
 /**
  * Gabe is a robot for the 2025-2026 DECODE FTC Season.
@@ -46,10 +46,10 @@ class Gabe(hardwareMap: HardwareMap, initialPose: Pose2d = Pose2d(Vector2d(0.0, 
 
     // Drivetrain
     val drivetrain =
-        SimpleMecanumDriveWithRR(
+        MecanumDriveWithRR(
             hardwareMap,
             initialPose,
-            SimpleMecanumDriveWithRR.DriveParams(
+            MecanumDriveWithRR.DriveParams(
                 logoFacingDirection = logoFacingDirection,
                 usbFacingDirection = usbFacingDirection,
                 inPerTick = inPerTick,
@@ -72,7 +72,11 @@ class Gabe(hardwareMap: HardwareMap, initialPose: Pose2d = Pose2d(Vector2d(0.0, 
     // Hardware
     private val huskyLens by huskyLens("lens")
 
+    private val leftLauncherMotor by motor("fll")
+    private val rightLauncherMotor by motor("flr")
+
     // Attachments
+    val launcher = Launcher(leftLauncherMotor, rightLauncherMotor)
 
     /**
      * Get detected AprilTags from HuskyLens.

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Gabe.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Gabe.kt
@@ -72,5 +72,5 @@ inline fun <D : MecanumDrivetrain, T : Gabe<D>> VoltActionBuilder<T>.launcher(bl
 
 @VoltBuilderDsl
 inline fun <D : MecanumDrivetrain, T : Gabe<D>> VoltActionBuilder<T>.storage(block: Storage.() -> Action) {
-    block(robot.storage)
+    +block(robot.storage)
 }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Gabe.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Gabe.kt
@@ -3,11 +3,11 @@ package org.firstinspires.ftc.teamcode.robot
 import com.acmerobotics.dashboard.config.Config
 import com.acmerobotics.roadrunner.*
 import com.qualcomm.hardware.dfrobot.HuskyLens
-import com.qualcomm.hardware.rev.RevHubOrientationOnRobot.LogoFacingDirection
-import com.qualcomm.hardware.rev.RevHubOrientationOnRobot.UsbFacingDirection
 import com.qualcomm.robotcore.hardware.*
-import dev.kingssack.volt.drivetrain.MecanumDriveWithRR
-import dev.kingssack.volt.robot.Robot
+import dev.kingssack.volt.core.VoltActionBuilder
+import dev.kingssack.volt.core.VoltBuilderDsl
+import dev.kingssack.volt.attachment.drivetrain.MecanumDrivetrain
+import dev.kingssack.volt.robot.RobotWithMecanumDrivetrain
 import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.teamcode.attachment.Launcher
 import org.firstinspires.ftc.teamcode.attachment.Storage
@@ -16,60 +16,10 @@ import org.firstinspires.ftc.teamcode.attachment.Storage
  * Gabe is a robot for the 2025-2026 DECODE FTC Season.
  *
  * @param hardwareMap for initializing hardware components
- * @param initialPose for setting the initial pose
  */
 @Config
-class Gabe(hardwareMap: HardwareMap, initialPose: Pose2d = Pose2d(Vector2d(0.0, 0.0), 0.0)) :
-    Robot(hardwareMap) {
-    companion object {
-        @JvmField var logoFacingDirection: LogoFacingDirection = LogoFacingDirection.UP
-        @JvmField var usbFacingDirection: UsbFacingDirection = UsbFacingDirection.RIGHT
-
-        @JvmField var inPerTick: Double = 0.0227
-        @JvmField var lateralInPerTick: Double = 0.02
-        @JvmField var trackWidthTicks: Double = 1297.32
-
-        @JvmField var kS: Double = 0.9134
-        @JvmField var kV: Double = 0.0043
-        @JvmField var kA: Double = 0.001
-
-        @JvmField var maxWheelVel: Double = 60.0
-        @JvmField var minProfileAccel: Double = -30.0
-        @JvmField var maxProfileAccel: Double = 60.0
-
-        @JvmField var maxAngVel: Double = Math.PI
-        @JvmField var maxAngAccel: Double = Math.PI
-
-        @JvmField var axialGain: Double = 5.0
-        @JvmField var lateralGain: Double = 4.0
-        @JvmField var headingGain: Double = 3.0
-    }
-
-    // Drivetrain
-    val drivetrain =
-        MecanumDriveWithRR(
-            hardwareMap,
-            initialPose,
-            MecanumDriveWithRR.DriveParams(
-                logoFacingDirection = logoFacingDirection,
-                usbFacingDirection = usbFacingDirection,
-                inPerTick = inPerTick,
-                lateralInPerTick = lateralInPerTick,
-                trackWidthTicks = trackWidthTicks,
-                kS = kS,
-                kV = kV,
-                kA = kA,
-                maxWheelVel = maxWheelVel,
-                minProfileAccel = minProfileAccel,
-                maxProfileAccel = maxProfileAccel,
-                maxAngVel = maxAngVel,
-                maxAngAccel = maxAngAccel,
-                axialGain = axialGain,
-                lateralGain = lateralGain,
-                headingGain = headingGain,
-            ),
-        )
-
+abstract class Gabe<T : MecanumDrivetrain>(hardwareMap: HardwareMap, drivetrain: T) :
+    RobotWithMecanumDrivetrain<T>(hardwareMap, drivetrain) {
     // Hardware
     private val huskyLens by huskyLens("lens")
 
@@ -79,12 +29,8 @@ class Gabe(hardwareMap: HardwareMap, initialPose: Pose2d = Pose2d(Vector2d(0.0, 
     private val storageServo by servo("ss")
 
     // Attachments
-    val launcher = Launcher(leftLauncherMotor, rightLauncherMotor)
-    val storage = Storage(storageServo)
-
-    init {
-        attachments.addAll(listOf(launcher, storage))
-    }
+    val launcher by attachment { Launcher(leftLauncherMotor, rightLauncherMotor) }
+    val storage by attachment { Storage(storageServo) }
 
     /**
      * Get detected AprilTags from HuskyLens.
@@ -117,10 +63,14 @@ class Gabe(hardwareMap: HardwareMap, initialPose: Pose2d = Pose2d(Vector2d(0.0, 
 
         return result
     }
+}
 
-    context(telemetry: Telemetry)
-    override fun update() {
-        drivetrain.update()
-        super.update()
-    }
+@VoltBuilderDsl
+inline fun <D : MecanumDrivetrain, T : Gabe<D>> VoltActionBuilder<T>.launcher(block: Launcher.() -> Action) {
+    block(robot.launcher)
+}
+
+@VoltBuilderDsl
+inline fun <D : MecanumDrivetrain, T : Gabe<D>> VoltActionBuilder<T>.storage(block: Storage.() -> Action) {
+    block(robot.storage)
 }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Gabe.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Gabe.kt
@@ -10,6 +10,7 @@ import dev.kingssack.volt.drivetrain.MecanumDriveWithRR
 import dev.kingssack.volt.robot.Robot
 import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.teamcode.attachment.Launcher
+import org.firstinspires.ftc.teamcode.attachment.Storage
 
 /**
  * Gabe is a robot for the 2025-2026 DECODE FTC Season.
@@ -75,8 +76,11 @@ class Gabe(hardwareMap: HardwareMap, initialPose: Pose2d = Pose2d(Vector2d(0.0, 
     private val leftLauncherMotor by motor("fll")
     private val rightLauncherMotor by motor("flr")
 
+    private val storageServo by servo("ss")
+
     // Attachments
     val launcher = Launcher(leftLauncherMotor, rightLauncherMotor)
+    val storage = Storage(storageServo)
 
     /**
      * Get detected AprilTags from HuskyLens.

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/GabePP.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/GabePP.kt
@@ -15,14 +15,14 @@ import dev.kingssack.volt.attachment.drivetrain.MecanumDriveWithPP
 import org.firstinspires.ftc.robotcore.external.Telemetry
 
 /**
- * [Jones] with [MecanumDriveWithPP] drivetrain.
+ * [Gabe] with [MecanumDriveWithPP] drivetrain.
  *
  * @param hardwareMap The FTC hardware map.
  * @param initialPose The initial pose of the robot.
  */
 @Config
-class JonesPP(hardwareMap: HardwareMap, initialPose: Pose = Pose()) :
-    Jones<MecanumDriveWithPP>(
+class GabePP(hardwareMap: HardwareMap, initialPose: Pose = Pose()) :
+    Gabe<MecanumDriveWithPP>(
         hardwareMap,
         MecanumDriveWithPP(
             hardwareMap,

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/GabeRR.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/GabeRR.kt
@@ -10,35 +10,35 @@ import dev.kingssack.volt.attachment.drivetrain.MecanumDriveWithRR
 import org.firstinspires.ftc.robotcore.external.Telemetry
 
 /**
- * [Jones] with [MecanumDriveWithRR] drivetrain.
+ * [Gabe] with [MecanumDriveWithRR] drivetrain.
  *
  * @param hardwareMap The FTC hardware map.
  * @param initialPose The initial pose of the robot.
  */
 @Config
-class JonesRR(hardwareMap: HardwareMap, initialPose: Pose2d = Pose2d(Vector2d(0.0, 0.0), 0.0)) :
-    Jones<MecanumDriveWithRR>(
+class GabeRR(hardwareMap: HardwareMap, initialPose: Pose2d = Pose2d(Vector2d(0.0, 0.0), 0.0)) :
+    Gabe<MecanumDriveWithRR>(
         hardwareMap,
         MecanumDriveWithRR(
             hardwareMap,
             initialPose,
             MecanumDriveWithRR.DriveParams(
-                logoFacingDirection = logoFacingDirection,
-                usbFacingDirection = usbFacingDirection,
-                inPerTick = inPerTick,
-                lateralInPerTick = lateralInPerTick,
-                trackWidthTicks = trackWidthTicks,
-                kS = kS,
-                kV = kV,
-                kA = kA,
-                maxWheelVel = maxWheelVel,
-                minProfileAccel = minProfileAccel,
-                maxProfileAccel = maxProfileAccel,
-                maxAngVel = maxAngVel,
-                maxAngAccel = maxAngAccel,
-                axialGain = axialGain,
-                lateralGain = lateralGain,
-                headingGain = headingGain,
+                logoFacingDirection,
+                usbFacingDirection,
+                inPerTick,
+                lateralInPerTick,
+                trackWidthTicks,
+                kS,
+                kV,
+                kA,
+                maxWheelVel,
+                minProfileAccel,
+                maxProfileAccel,
+                maxAngVel,
+                maxAngAccel,
+                axialGain,
+                lateralGain,
+                headingGain,
             ),
         ),
     ) {

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Jones.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Jones.kt
@@ -1,10 +1,10 @@
 package org.firstinspires.ftc.teamcode.robot
 
 import com.acmerobotics.dashboard.config.Config
-import com.pedropathing.geometry.Pose
 import com.qualcomm.hardware.dfrobot.HuskyLens
 import com.qualcomm.robotcore.hardware.*
-import dev.kingssack.volt.robot.Robot
+import dev.kingssack.volt.attachment.drivetrain.MecanumDrivetrain
+import dev.kingssack.volt.robot.RobotWithMecanumDrivetrain
 import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit
 
@@ -12,10 +12,10 @@ import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit
  * Jones is a robot for the 2025-2026 DECODE FTC Season.
  *
  * @param hardwareMap for initializing hardware components
- * @param initialPose for setting the initial pose
  */
 @Config
-open class Jones(hardwareMap: HardwareMap, initialPose: Pose = Pose()) : Robot(hardwareMap) {
+abstract class Jones<T : MecanumDrivetrain>(hardwareMap: HardwareMap, drivetrain: T) :
+    RobotWithMecanumDrivetrain<T>(hardwareMap, drivetrain) {
     companion object {
         @JvmField var lidarLeftName: String = "lidarl"
         @JvmField var lidarRightName: String = "lidarr"

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Jones.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Jones.kt
@@ -4,11 +4,10 @@ import com.acmerobotics.dashboard.config.Config
 import com.pedropathing.geometry.Pose
 import com.qualcomm.hardware.dfrobot.HuskyLens
 import com.qualcomm.robotcore.hardware.*
-import dev.kingssack.volt.drivetrain.SimpleMecanumDriveWithPP
+import dev.kingssack.volt.drivetrain.MecanumDriveWithPP
 import dev.kingssack.volt.robot.Robot
 import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit
-import org.firstinspires.ftc.teamcode.attachment.Launcher
 import org.firstinspires.ftc.teamcode.pp.Constants
 
 /**
@@ -23,14 +22,11 @@ class Jones(hardwareMap: HardwareMap, initialPose: Pose = Pose()) : Robot(hardwa
         @JvmField var lidarLeftName: String = "lidarl"
         @JvmField var lidarRightName: String = "lidarr"
         @JvmField var huskyLensName: String = "lens"
-
-        @JvmField var leftLauncherMotorName: String = "fll"
-        @JvmField var rightLauncherMotorName: String = "flr"
     }
 
     // Drivetrain
     val drivetrain =
-        SimpleMecanumDriveWithPP(
+        MecanumDriveWithPP(
             hardwareMap,
             Constants.followerConstants,
             Constants.localizerConstants,
@@ -44,11 +40,7 @@ class Jones(hardwareMap: HardwareMap, initialPose: Pose = Pose()) : Robot(hardwa
     private val lidarRight by distanceSensor(lidarRightName)
     private val huskyLens by huskyLens(huskyLensName)
 
-    private val leftLauncherMotor by motor(leftLauncherMotorName)
-    private val rightLauncherMotor by motor(rightLauncherMotorName)
-
     // Attachments
-    val launcher = Launcher(leftLauncherMotor, rightLauncherMotor)
 
     init {
         // Set huskylens mode

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Jones.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/Jones.kt
@@ -4,11 +4,9 @@ import com.acmerobotics.dashboard.config.Config
 import com.pedropathing.geometry.Pose
 import com.qualcomm.hardware.dfrobot.HuskyLens
 import com.qualcomm.robotcore.hardware.*
-import dev.kingssack.volt.drivetrain.MecanumDriveWithPP
 import dev.kingssack.volt.robot.Robot
 import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit
-import org.firstinspires.ftc.teamcode.pp.Constants
 
 /**
  * Jones is a robot for the 2025-2026 DECODE FTC Season.
@@ -17,23 +15,12 @@ import org.firstinspires.ftc.teamcode.pp.Constants
  * @param initialPose for setting the initial pose
  */
 @Config
-class Jones(hardwareMap: HardwareMap, initialPose: Pose = Pose()) : Robot(hardwareMap) {
+open class Jones(hardwareMap: HardwareMap, initialPose: Pose = Pose()) : Robot(hardwareMap) {
     companion object {
         @JvmField var lidarLeftName: String = "lidarl"
         @JvmField var lidarRightName: String = "lidarr"
         @JvmField var huskyLensName: String = "lens"
     }
-
-    // Drivetrain
-    val drivetrain =
-        MecanumDriveWithPP(
-            hardwareMap,
-            Constants.followerConstants,
-            Constants.localizerConstants,
-            Constants.pathConstraints,
-            Constants.driveConstants,
-            initialPose,
-        )
 
     // Hardware
     private val lidarLeft by distanceSensor(lidarLeftName)
@@ -97,11 +84,5 @@ class Jones(hardwareMap: HardwareMap, initialPose: Pose = Pose()) : Robot(hardwa
         telemetry.addData("Average range", "%.01f mm".format(averageDistance))
 
         return averageDistance
-    }
-
-    context(telemetry: Telemetry)
-    override fun update() {
-        drivetrain.update()
-        super.update()
     }
 }

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/JonesPP.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/JonesPP.kt
@@ -1,0 +1,123 @@
+package org.firstinspires.ftc.teamcode.robot
+
+import com.acmerobotics.dashboard.config.Config
+import com.pedropathing.control.FilteredPIDFCoefficients
+import com.pedropathing.control.PIDFCoefficients
+import com.pedropathing.follower.FollowerConstants
+import com.pedropathing.ftc.drivetrains.MecanumConstants
+import com.pedropathing.ftc.localization.Encoder
+import com.pedropathing.ftc.localization.constants.DriveEncoderConstants
+import com.pedropathing.geometry.Pose
+import com.pedropathing.paths.PathConstraints
+import com.qualcomm.robotcore.hardware.DcMotorSimple
+import com.qualcomm.robotcore.hardware.HardwareMap
+import dev.kingssack.volt.drivetrain.MecanumDriveWithPP
+import org.firstinspires.ftc.robotcore.external.Telemetry
+
+@Config
+class JonesPP(hardwareMap: HardwareMap, initialPose: Pose = Pose()) : Jones(hardwareMap) {
+    companion object {
+        @JvmField var mass: Double = 5.45
+        @JvmField var forwardZeroPowerAcceleration: Double = -70.0
+        @JvmField var lateralZeroPowerAcceleration: Double = -150.0
+        @JvmField
+        var translationalPIDFCoefficients: PIDFCoefficients = PIDFCoefficients(0.3, 0.0, 0.0, 0.015)
+        @JvmField
+        var headingPIDFCoefficients: PIDFCoefficients = PIDFCoefficients(0.8, 0.01, 0.01, 0.025)
+        @JvmField
+        var drivePIDFCoefficients: FilteredPIDFCoefficients =
+            FilteredPIDFCoefficients(0.8, 0.0, 0.02, 0.1, 0.1)
+        @JvmField var centripetalScaling: Double = 0.00054
+
+        @JvmField var rightFrontMotorName: String = "rf"
+        @JvmField var leftFrontMotorName: String = "lf"
+        @JvmField var rightRearMotorName: String = "rr"
+        @JvmField var leftRearMotorName: String = "lr"
+        @JvmField var leftFrontEncoderDirection: Double = Encoder.FORWARD
+        @JvmField var leftRearEncoderDirection: Double = Encoder.FORWARD
+        @JvmField var rightFrontEncoderDirection: Double = Encoder.REVERSE
+        @JvmField var rightRearEncoderDirection: Double = Encoder.REVERSE
+        @JvmField var robotWidth: Double = 13.0
+        @JvmField var robotLength: Double = 9.0
+        @JvmField var forwardTicksToInches: Double = 0.0057725
+        @JvmField var strafeTicksToInches: Double = 0.004527
+        @JvmField var turnTicksToInches: Double = 0.0092964
+
+        @JvmField var tValueConstraint: Double = 0.99
+        @JvmField var timeoutConstraint: Double = 100.0
+        @JvmField var brakingStrength: Double = 1.0
+        @JvmField var brakingStart: Double = 1.0
+
+        @JvmField var maxPower: Double = 1.0
+        @JvmField
+        var leftFrontMotorDirection: DcMotorSimple.Direction = DcMotorSimple.Direction.FORWARD
+        @JvmField
+        var leftRearMotorDirection: DcMotorSimple.Direction = DcMotorSimple.Direction.FORWARD
+        @JvmField
+        var rightFrontMotorDirection: DcMotorSimple.Direction = DcMotorSimple.Direction.REVERSE
+        @JvmField
+        var rightRearMotorDirection: DcMotorSimple.Direction = DcMotorSimple.Direction.REVERSE
+        @JvmField var xVelocity: Double = 50.0
+        @JvmField var yVelocity: Double = 55.0
+    }
+
+    // Drivetrain
+    private val followerConstants: FollowerConstants =
+        FollowerConstants()
+            .mass(mass)
+            .forwardZeroPowerAcceleration(forwardZeroPowerAcceleration)
+            .lateralZeroPowerAcceleration(lateralZeroPowerAcceleration)
+            .translationalPIDFCoefficients(translationalPIDFCoefficients)
+            .headingPIDFCoefficients(headingPIDFCoefficients)
+            .drivePIDFCoefficients(drivePIDFCoefficients)
+            .centripetalScaling(centripetalScaling)
+
+    private val localizerConstants: DriveEncoderConstants =
+        DriveEncoderConstants()
+            .rightFrontMotorName(rightFrontMotorName)
+            .rightRearMotorName(rightRearMotorName)
+            .leftRearMotorName(leftRearMotorName)
+            .leftFrontMotorName(leftFrontMotorName)
+            .leftFrontEncoderDirection(leftFrontEncoderDirection)
+            .leftRearEncoderDirection(leftRearEncoderDirection)
+            .rightFrontEncoderDirection(rightFrontEncoderDirection)
+            .rightRearEncoderDirection(rightRearEncoderDirection)
+            .robotWidth(robotWidth)
+            .robotLength(robotLength)
+            .forwardTicksToInches(forwardTicksToInches)
+            .strafeTicksToInches(strafeTicksToInches)
+            .turnTicksToInches(turnTicksToInches)
+
+    private val pathConstraints: PathConstraints =
+        PathConstraints(tValueConstraint, timeoutConstraint, brakingStrength, brakingStart)
+
+    private val driveConstants: MecanumConstants =
+        MecanumConstants()
+            .maxPower(maxPower)
+            .rightFrontMotorName(rightFrontMotorName)
+            .rightRearMotorName(rightRearMotorName)
+            .leftRearMotorName(leftRearMotorName)
+            .leftFrontMotorName(leftFrontMotorName)
+            .leftFrontMotorDirection(leftFrontMotorDirection)
+            .leftRearMotorDirection(leftRearMotorDirection)
+            .rightFrontMotorDirection(rightFrontMotorDirection)
+            .rightRearMotorDirection(rightRearMotorDirection)
+            .xVelocity(xVelocity)
+            .yVelocity(yVelocity)
+
+    val drivetrain =
+        MecanumDriveWithPP(
+            hardwareMap,
+            followerConstants,
+            localizerConstants,
+            pathConstraints,
+            driveConstants,
+            initialPose,
+        )
+
+    context(telemetry: Telemetry)
+    override fun update() {
+        drivetrain.update()
+        super.update()
+    }
+}

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/JonesRR.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/robot/JonesRR.kt
@@ -1,26 +1,17 @@
 package org.firstinspires.ftc.teamcode.robot
 
 import com.acmerobotics.dashboard.config.Config
-import com.acmerobotics.roadrunner.*
-import com.qualcomm.hardware.dfrobot.HuskyLens
+import com.acmerobotics.roadrunner.Pose2d
+import com.acmerobotics.roadrunner.Vector2d
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot.LogoFacingDirection
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot.UsbFacingDirection
-import com.qualcomm.robotcore.hardware.*
+import com.qualcomm.robotcore.hardware.HardwareMap
 import dev.kingssack.volt.drivetrain.MecanumDriveWithRR
-import dev.kingssack.volt.robot.Robot
 import org.firstinspires.ftc.robotcore.external.Telemetry
-import org.firstinspires.ftc.teamcode.attachment.Launcher
-import org.firstinspires.ftc.teamcode.attachment.Storage
 
-/**
- * Gabe is a robot for the 2025-2026 DECODE FTC Season.
- *
- * @param hardwareMap for initializing hardware components
- * @param initialPose for setting the initial pose
- */
 @Config
-class Gabe(hardwareMap: HardwareMap, initialPose: Pose2d = Pose2d(Vector2d(0.0, 0.0), 0.0)) :
-    Robot(hardwareMap) {
+class JonesRR(hardwareMap: HardwareMap, initialPose: Pose2d = Pose2d(Vector2d(0.0, 0.0), 0.0)) :
+    Jones(hardwareMap) {
     companion object {
         @JvmField var logoFacingDirection: LogoFacingDirection = LogoFacingDirection.UP
         @JvmField var usbFacingDirection: UsbFacingDirection = UsbFacingDirection.RIGHT
@@ -69,54 +60,6 @@ class Gabe(hardwareMap: HardwareMap, initialPose: Pose2d = Pose2d(Vector2d(0.0, 
                 headingGain = headingGain,
             ),
         )
-
-    // Hardware
-    private val huskyLens by huskyLens("lens")
-
-    private val leftLauncherMotor by motor("fll")
-    private val rightLauncherMotor by motor("flr")
-
-    private val storageServo by servo("ss")
-
-    // Attachments
-    val launcher = Launcher(leftLauncherMotor, rightLauncherMotor)
-    val storage = Storage(storageServo)
-
-    init {
-        attachments.addAll(listOf(launcher, storage))
-    }
-
-    /**
-     * Get detected AprilTags from HuskyLens.
-     *
-     * @return array of detected AprilTags
-     * @see HuskyLens
-     * @see HuskyLens.Block
-     */
-    context(telemetry: Telemetry)
-    fun getDetectedAprilTags(id: Int? = null): Array<out HuskyLens.Block> {
-        // Get AprilTags
-        val blocks = huskyLens.blocks()
-        telemetry.addData("Block count", blocks.size)
-
-        // If an id is provided, filter to matching blocks; otherwise return all blocks.
-        val result: Array<out HuskyLens.Block> =
-            if (id == null) {
-                blocks
-            } else {
-                blocks.filter { it.id == id }.toTypedArray()
-            }
-
-        // Log each block in the result
-        for (block in result) {
-            telemetry.addData("Block", block.toString())
-        }
-
-        // Also log the filtered count (useful when id was provided)
-        telemetry.addData("Filtered count", result.size)
-
-        return result
-    }
 
     context(telemetry: Telemetry)
     override fun update() {

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/rr/Tuning.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/rr/Tuning.kt
@@ -15,7 +15,7 @@ import com.qualcomm.hardware.rev.RevHubOrientationOnRobot.LogoFacingDirection
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot.UsbFacingDirection
 import com.qualcomm.robotcore.eventloop.opmode.*
 import com.qualcomm.robotcore.hardware.HardwareMap
-import dev.kingssack.volt.drivetrain.SimpleMecanumDriveWithRR
+import dev.kingssack.volt.drivetrain.MecanumDriveWithRR
 import dev.kingssack.volt.robot.Robot
 import dev.kingssack.volt.util.Drawing.drawRobot
 import java.util.*
@@ -48,10 +48,10 @@ class TestRobot(hardwareMap: HardwareMap, initialPose: Pose2d) : Robot(hardwareM
     }
 
     val drive =
-        SimpleMecanumDriveWithRR(
+        MecanumDriveWithRR(
             hardwareMap,
             initialPose,
-            SimpleMecanumDriveWithRR.DriveParams(
+            MecanumDriveWithRR.DriveParams(
                 logoFacingDirection,
                 usbFacingDirection,
                 inPerTick,

--- a/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/rr/Tuning.kt
+++ b/TeamCode/src/main/kotlin/org/firstinspires/ftc/teamcode/rr/Tuning.kt
@@ -15,7 +15,7 @@ import com.qualcomm.hardware.rev.RevHubOrientationOnRobot.LogoFacingDirection
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot.UsbFacingDirection
 import com.qualcomm.robotcore.eventloop.opmode.*
 import com.qualcomm.robotcore.hardware.HardwareMap
-import dev.kingssack.volt.drivetrain.MecanumDriveWithRR
+import dev.kingssack.volt.attachment.drivetrain.MecanumDriveWithRR
 import dev.kingssack.volt.robot.Robot
 import dev.kingssack.volt.util.Drawing.drawRobot
 import java.util.*

--- a/Volt/build.gradle
+++ b/Volt/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.dokka'
 
 group = 'dev.kingssack'
-version = '0.3.2'
+version = '0.3.3'
 
 android {
     defaultConfig {

--- a/Volt/src/main/kotlin/dev/kingssack/volt/attachment/Attachment.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/attachment/Attachment.kt
@@ -68,39 +68,28 @@ abstract class Attachment(val name: String) {
                 private var initialized = false
 
                 override fun run(p: TelemetryPacket): Boolean {
-                    if (!initialized) {
-                        runCatching { init?.invoke() }
-                            .onFailure { e ->
-                                setState(AttachmentState.Fault(e))
-                                runCatching { cleanup?.invoke() }
-                                    .onFailure { e ->
-                                        setState(AttachmentState.Fault(e))
-                                        throw e
-                                    }
-                                throw e
-                            }
-                        setState(AttachmentState.Running)
-                        initialized = true
+                    return try {
+                        if (!initialized) {
+                            init?.invoke()
+                            setState(AttachmentState.Running)
+                            initialized = true
+                        }
+                        val done = loop?.invoke(p) ?: true
+                        if (done) {
+                            cleanup?.invoke()
+                            setState(AttachmentState.Idle)
+                        }
+                        !done
+                    } catch (e: Throwable) {
+                        setState(AttachmentState.Fault(e))
+                        try {
+                            cleanup?.invoke()
+                        } catch (ce: Throwable) {
+                            setState(AttachmentState.Fault(ce))
+                            throw ce
+                        }
+                        throw e
                     }
-
-                    val done =
-                        runCatching { loop?.invoke(p) }
-                            .onFailure { e ->
-                                setState(AttachmentState.Fault(e))
-                                cleanup?.invoke()
-                                throw e
-                            }
-                            .getOrDefault(true)
-
-                    if (done == true) {
-                        setState(AttachmentState.Idle)
-                        runCatching { cleanup?.invoke() }
-                            .onFailure { e ->
-                                setState(AttachmentState.Fault(e))
-                                throw e
-                            }
-                    }
-                    return done == true
                 }
             }
     }

--- a/Volt/src/main/kotlin/dev/kingssack/volt/attachment/Attachment.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/attachment/Attachment.kt
@@ -112,7 +112,7 @@ abstract class Attachment(val name: String) {
     /** Updates the telemetry with the current state of the attachment. */
     context(telemetry: Telemetry)
     open fun update() {
-        with (telemetry) {
+        with(telemetry) {
             addLine()
             addLine("$name-->")
             addData("State", state.value)

--- a/Volt/src/main/kotlin/dev/kingssack/volt/attachment/Attachment.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/attachment/Attachment.kt
@@ -69,7 +69,6 @@ abstract class Attachment(val name: String) {
 
                 override fun run(p: TelemetryPacket): Boolean {
                     if (!initialized) {
-                        setState(AttachmentState.Running)
                         runCatching { init?.invoke() }
                             .onFailure { e ->
                                 setState(AttachmentState.Fault(e))
@@ -80,6 +79,7 @@ abstract class Attachment(val name: String) {
                                     }
                                 throw e
                             }
+                        setState(AttachmentState.Running)
                         initialized = true
                     }
 

--- a/Volt/src/main/kotlin/dev/kingssack/volt/attachment/drivetrain/Drivetrain.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/attachment/drivetrain/Drivetrain.kt
@@ -1,5 +1,6 @@
-package dev.kingssack.volt.drivetrain
+package dev.kingssack.volt.attachment.drivetrain
 
 import dev.kingssack.volt.attachment.Attachment
 
+/** Base class for all drivetrain attachments. */
 abstract class Drivetrain : Attachment("Drivetrain")

--- a/Volt/src/main/kotlin/dev/kingssack/volt/attachment/drivetrain/MecanumDriveWithPP.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/attachment/drivetrain/MecanumDriveWithPP.kt
@@ -1,4 +1,4 @@
-package dev.kingssack.volt.drivetrain
+package dev.kingssack.volt.attachment.drivetrain
 
 import com.acmerobotics.roadrunner.Action
 import com.acmerobotics.roadrunner.PoseVelocity2d
@@ -11,9 +11,19 @@ import com.pedropathing.geometry.Pose
 import com.pedropathing.paths.PathChain
 import com.pedropathing.paths.PathConstraints
 import com.qualcomm.robotcore.hardware.HardwareMap
-import dev.kingssack.volt.attachment.Attachment
 import org.firstinspires.ftc.robotcore.external.Telemetry
 
+/**
+ * A mecanum drivetrain integrated with the PedroPathing library.
+ *
+ * @param hardwareMap The FTC hardware map.
+ * @param followerConstants Constants for the path follower.
+ * @param localizerConstants Constants for the drive encoder localizer.
+ * @param pathConstraints Constraints for path following.
+ * @param driveConstants Constants specific to the mecanum drivetrain.
+ * @property pose The initial pose of the robot.
+ * @property follower The path follower instance.
+ */
 class MecanumDriveWithPP(
     hardwareMap: HardwareMap,
     followerConstants: FollowerConstants,
@@ -21,7 +31,7 @@ class MecanumDriveWithPP(
     pathConstraints: PathConstraints,
     driveConstants: MecanumConstants,
     var pose: Pose = Pose(),
-) : Drivetrain() {
+) : MecanumDrivetrain() {
     val follower: Follower =
         FollowerBuilder(followerConstants, hardwareMap)
             .driveEncoderLocalizer(localizerConstants)
@@ -38,7 +48,7 @@ class MecanumDriveWithPP(
         follower.startTeleOpDrive()
     }
 
-    fun setDrivePowers(powers: PoseVelocity2d) {
+    override fun setDrivePowers(powers: PoseVelocity2d) {
         follower.setTeleOpDrive(powers.linearVel.x, powers.linearVel.y, powers.angVel)
     }
 

--- a/Volt/src/main/kotlin/dev/kingssack/volt/attachment/drivetrain/MecanumDriveWithRR.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/attachment/drivetrain/MecanumDriveWithRR.kt
@@ -1,4 +1,4 @@
-package dev.kingssack.volt.drivetrain
+package dev.kingssack.volt.attachment.drivetrain
 
 import com.acmerobotics.dashboard.canvas.Canvas
 import com.acmerobotics.dashboard.telemetry.TelemetryPacket
@@ -46,10 +46,7 @@ import com.qualcomm.robotcore.hardware.IMU
 import com.qualcomm.robotcore.hardware.VoltageSensor
 import dev.kingssack.volt.util.Degrees
 import dev.kingssack.volt.util.Drawing
-import dev.kingssack.volt.util.DriveCommandMessage
 import dev.kingssack.volt.util.Localizer
-import dev.kingssack.volt.util.MecanumCommandMessage
-import dev.kingssack.volt.util.PoseMessage
 import dev.kingssack.volt.util.Radians
 import dev.kingssack.volt.util.Seconds
 import dev.kingssack.volt.util.toRadians
@@ -59,11 +56,25 @@ import kotlin.math.max
 import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit
 
+/**
+ * A mecanum drivetrain integrated with the RoadRunner library.
+ *
+ * @param hardwareMap the hardware map
+ * @property pose the pose
+ * @param params the drive parameters
+ * @property leftFront the left front motor
+ * @property leftBack the left back motor
+ * @property rightBack the right back motor
+ * @property rightFront the right front motor
+ * @property voltageSensor the voltage sensor
+ * @property lazyImu the lazy IMU
+ * @property localizer the drive localizer
+ */
 class MecanumDriveWithRR(
     hardwareMap: HardwareMap,
     var pose: Pose2d = Pose2d(Vector2d(0.0, 0.0), 0.0),
     private val params: DriveParams = DriveParams(),
-) : Drivetrain() {
+) : MecanumDrivetrain() {
     /**
      * Parameters for the robot's mecanum drive.
      *
@@ -271,7 +282,7 @@ class MecanumDriveWithRR(
      * @param powers the drive powers
      * @see PoseVelocity2d
      */
-    fun setDrivePowers(powers: PoseVelocity2d) {
+    override fun setDrivePowers(powers: PoseVelocity2d) {
         val wheelVels = MecanumKinematics(1.0).inverse(PoseVelocity2dDual.constant<Time>(powers, 1))
 
         var maxPowerMag = 1.0
@@ -326,7 +337,7 @@ class MecanumDriveWithRR(
             }
 
             val txWorldTarget = timeTrajectory[t]
-//            targetPoseWriter.write(PoseMessage(txWorldTarget.value()))
+            //            targetPoseWriter.write(PoseMessage(txWorldTarget.value()))
 
             val robotVelRobot = updatePoseEstimate()
 
@@ -340,7 +351,7 @@ class MecanumDriveWithRR(
                         params.headingVelGain,
                     )
                     .compute(txWorldTarget, localizer.pose, robotVelRobot)
-//            driveCommandWriter.write(DriveCommandMessage(command))
+            //            driveCommandWriter.write(DriveCommandMessage(command))
 
             val wheelVels = kinematics.inverse(command)
             val voltage = voltageSensor.voltage
@@ -355,15 +366,15 @@ class MecanumDriveWithRR(
             val leftBackPower = feedforward.compute(wheelVels.leftBack) / voltage
             val rightBackPower = feedforward.compute(wheelVels.rightBack) / voltage
             val rightFrontPower = feedforward.compute(wheelVels.rightFront) / voltage
-//            mecanumCommandWriter.write(
-//                MecanumCommandMessage(
-//                    voltage,
-//                    leftFrontPower,
-//                    leftBackPower,
-//                    rightBackPower,
-//                    rightFrontPower,
-//                )
-//            )
+            //            mecanumCommandWriter.write(
+            //                MecanumCommandMessage(
+            //                    voltage,
+            //                    leftFrontPower,
+            //                    leftBackPower,
+            //                    rightBackPower,
+            //                    rightFrontPower,
+            //                )
+            //            )
 
             leftFront.power = leftFrontPower
             leftBack.power = leftBackPower
@@ -424,7 +435,7 @@ class MecanumDriveWithRR(
             }
 
             val txWorldTarget = turn[t]
-//            targetPoseWriter.write(PoseMessage(txWorldTarget.value()))
+            //            targetPoseWriter.write(PoseMessage(txWorldTarget.value()))
 
             val robotVelRobot = updatePoseEstimate()
 
@@ -438,7 +449,7 @@ class MecanumDriveWithRR(
                         params.headingVelGain,
                     )
                     .compute(txWorldTarget, localizer.pose, robotVelRobot)
-//            driveCommandWriter.write(DriveCommandMessage(command))
+            //            driveCommandWriter.write(DriveCommandMessage(command))
 
             val wheelVels = kinematics.inverse(command)
             val voltage = voltageSensor.voltage
@@ -452,15 +463,15 @@ class MecanumDriveWithRR(
             val leftBackPower = feedforward.compute(wheelVels.leftBack) / voltage
             val rightBackPower = feedforward.compute(wheelVels.rightBack) / voltage
             val rightFrontPower = feedforward.compute(wheelVels.rightFront) / voltage
-//            mecanumCommandWriter.write(
-//                MecanumCommandMessage(
-//                    voltage,
-//                    leftFrontPower,
-//                    leftBackPower,
-//                    rightBackPower,
-//                    rightFrontPower,
-//                )
-//            )
+            //            mecanumCommandWriter.write(
+            //                MecanumCommandMessage(
+            //                    voltage,
+            //                    leftFrontPower,
+            //                    leftBackPower,
+            //                    rightBackPower,
+            //                    rightFrontPower,
+            //                )
+            //            )
 
             leftFront.power = feedforward.compute(wheelVels.leftFront) / voltage
             leftBack.power = feedforward.compute(wheelVels.leftBack) / voltage

--- a/Volt/src/main/kotlin/dev/kingssack/volt/attachment/drivetrain/MecanumDrivetrain.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/attachment/drivetrain/MecanumDrivetrain.kt
@@ -1,0 +1,8 @@
+package dev.kingssack.volt.attachment.drivetrain
+
+import com.acmerobotics.roadrunner.PoseVelocity2d
+
+/** A drivetrain implementation for robots with mecanum wheels. */
+abstract class MecanumDrivetrain : Drivetrain() {
+    abstract fun setDrivePowers(powers: PoseVelocity2d)
+}

--- a/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/Drivetrain.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/Drivetrain.kt
@@ -1,9 +1,5 @@
 package dev.kingssack.volt.drivetrain
 
 import dev.kingssack.volt.attachment.Attachment
-import org.firstinspires.ftc.robotcore.external.Telemetry
 
-abstract class Drivetrain : Attachment("Drivetrain") {
-    context(telemetry: Telemetry)
-    abstract override fun update()
-}
+abstract class Drivetrain : Attachment("Drivetrain")

--- a/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/Drivetrain.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/Drivetrain.kt
@@ -1,8 +1,9 @@
 package dev.kingssack.volt.drivetrain
 
+import dev.kingssack.volt.attachment.Attachment
 import org.firstinspires.ftc.robotcore.external.Telemetry
 
-abstract class Drivetrain {
+abstract class Drivetrain : Attachment("Drivetrain") {
     context(telemetry: Telemetry)
-    abstract fun update()
+    abstract override fun update()
 }

--- a/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/MecanumDriveWithPP.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/MecanumDriveWithPP.kt
@@ -13,7 +13,7 @@ import com.pedropathing.paths.PathConstraints
 import com.qualcomm.robotcore.hardware.HardwareMap
 import org.firstinspires.ftc.robotcore.external.Telemetry
 
-class SimpleMecanumDriveWithPP(
+class MecanumDriveWithPP(
     hardwareMap: HardwareMap,
     followerConstants: FollowerConstants,
     localizerConstants: DriveEncoderConstants,
@@ -47,14 +47,14 @@ class SimpleMecanumDriveWithPP(
         follower.update()
         val finished = !follower.isBusy
 
-        finished
+        !finished
     }
 
     context(telemetry: Telemetry)
     override fun update() {
         follower.update()
 
-        telemetry.addLine("DRIVETRAIN-->")
+        super.update()
         telemetry.addData("x", follower.pose.x)
         telemetry.addData("y", follower.pose.y)
         telemetry.addData("heading", follower.pose.heading)

--- a/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/MecanumDriveWithPP.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/MecanumDriveWithPP.kt
@@ -11,6 +11,7 @@ import com.pedropathing.geometry.Pose
 import com.pedropathing.paths.PathChain
 import com.pedropathing.paths.PathConstraints
 import com.qualcomm.robotcore.hardware.HardwareMap
+import dev.kingssack.volt.attachment.Attachment
 import org.firstinspires.ftc.robotcore.external.Telemetry
 
 class MecanumDriveWithPP(

--- a/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/MecanumDriveWithRR.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/MecanumDriveWithRR.kt
@@ -59,7 +59,7 @@ import kotlin.math.max
 import org.firstinspires.ftc.robotcore.external.Telemetry
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit
 
-class SimpleMecanumDriveWithRR(
+class MecanumDriveWithRR(
     hardwareMap: HardwareMap,
     var pose: Pose2d = Pose2d(Vector2d(0.0, 0.0), 0.0),
     private val params: DriveParams = DriveParams(),

--- a/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/MecanumDriveWithRR.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/drivetrain/MecanumDriveWithRR.kt
@@ -247,7 +247,7 @@ class MecanumDriveWithRR(
         }
 
         init {
-            rightFront.direction = DcMotorSimple.Direction.REVERSE
+            leftBack.direction = DcMotorSimple.Direction.REVERSE
             rightBack.direction = DcMotorSimple.Direction.REVERSE
         }
     }
@@ -261,7 +261,7 @@ class MecanumDriveWithRR(
 
         driveMotors.forEach { it.zeroPowerBehavior = DcMotor.ZeroPowerBehavior.BRAKE }
 
-        rightFront.direction = DcMotorSimple.Direction.REVERSE
+        leftBack.direction = DcMotorSimple.Direction.REVERSE
         rightBack.direction = DcMotorSimple.Direction.REVERSE
     }
 
@@ -326,7 +326,7 @@ class MecanumDriveWithRR(
             }
 
             val txWorldTarget = timeTrajectory[t]
-            targetPoseWriter.write(PoseMessage(txWorldTarget.value()))
+//            targetPoseWriter.write(PoseMessage(txWorldTarget.value()))
 
             val robotVelRobot = updatePoseEstimate()
 
@@ -340,7 +340,7 @@ class MecanumDriveWithRR(
                         params.headingVelGain,
                     )
                     .compute(txWorldTarget, localizer.pose, robotVelRobot)
-            driveCommandWriter.write(DriveCommandMessage(command))
+//            driveCommandWriter.write(DriveCommandMessage(command))
 
             val wheelVels = kinematics.inverse(command)
             val voltage = voltageSensor.voltage
@@ -355,15 +355,15 @@ class MecanumDriveWithRR(
             val leftBackPower = feedforward.compute(wheelVels.leftBack) / voltage
             val rightBackPower = feedforward.compute(wheelVels.rightBack) / voltage
             val rightFrontPower = feedforward.compute(wheelVels.rightFront) / voltage
-            mecanumCommandWriter.write(
-                MecanumCommandMessage(
-                    voltage,
-                    leftFrontPower,
-                    leftBackPower,
-                    rightBackPower,
-                    rightFrontPower,
-                )
-            )
+//            mecanumCommandWriter.write(
+//                MecanumCommandMessage(
+//                    voltage,
+//                    leftFrontPower,
+//                    leftBackPower,
+//                    rightBackPower,
+//                    rightFrontPower,
+//                )
+//            )
 
             leftFront.power = leftFrontPower
             leftBack.power = leftBackPower
@@ -424,7 +424,7 @@ class MecanumDriveWithRR(
             }
 
             val txWorldTarget = turn[t]
-            targetPoseWriter.write(PoseMessage(txWorldTarget.value()))
+//            targetPoseWriter.write(PoseMessage(txWorldTarget.value()))
 
             val robotVelRobot = updatePoseEstimate()
 
@@ -438,7 +438,7 @@ class MecanumDriveWithRR(
                         params.headingVelGain,
                     )
                     .compute(txWorldTarget, localizer.pose, robotVelRobot)
-            driveCommandWriter.write(DriveCommandMessage(command))
+//            driveCommandWriter.write(DriveCommandMessage(command))
 
             val wheelVels = kinematics.inverse(command)
             val voltage = voltageSensor.voltage
@@ -452,15 +452,15 @@ class MecanumDriveWithRR(
             val leftBackPower = feedforward.compute(wheelVels.leftBack) / voltage
             val rightBackPower = feedforward.compute(wheelVels.rightBack) / voltage
             val rightFrontPower = feedforward.compute(wheelVels.rightFront) / voltage
-            mecanumCommandWriter.write(
-                MecanumCommandMessage(
-                    voltage,
-                    leftFrontPower,
-                    leftBackPower,
-                    rightBackPower,
-                    rightFrontPower,
-                )
-            )
+//            mecanumCommandWriter.write(
+//                MecanumCommandMessage(
+//                    voltage,
+//                    leftFrontPower,
+//                    leftBackPower,
+//                    rightBackPower,
+//                    rightFrontPower,
+//                )
+//            )
 
             leftFront.power = feedforward.compute(wheelVels.leftFront) / voltage
             leftBack.power = feedforward.compute(wheelVels.leftBack) / voltage
@@ -612,10 +612,9 @@ class MecanumDriveWithRR(
     override fun update() {
         updatePoseEstimate()
 
-        telemetry.addLine("DRIVETRAIN-->")
+        super.update()
         telemetry.addData("x", localizer.pose.position.x)
         telemetry.addData("y", localizer.pose.position.y)
         telemetry.addData("heading (deg)", Math.toDegrees(localizer.pose.heading.toDouble()))
-        telemetry.addLine()
     }
 }

--- a/Volt/src/main/kotlin/dev/kingssack/volt/opmode/VoltOpMode.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/opmode/VoltOpMode.kt
@@ -1,0 +1,23 @@
+package dev.kingssack.volt.opmode
+
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
+import com.qualcomm.robotcore.hardware.HardwareMap
+import dev.kingssack.volt.robot.Robot
+
+abstract class VoltOpMode<R : Robot>(robotFactory: (HardwareMap) -> R) : LinearOpMode() {
+    protected val robot : R by lazy { robotFactory(hardwareMap) }
+
+    /** Optional initialization code. */
+    open fun initialize() {
+        // Default implementation does nothing
+    }
+
+    /** Optional code to run when the op mode begins. */
+    abstract fun begin()
+
+    override fun runOpMode() {
+        initialize()
+        waitForStart()
+        begin()
+    }
+}

--- a/Volt/src/main/kotlin/dev/kingssack/volt/opmode/VoltOpMode.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/opmode/VoltOpMode.kt
@@ -5,7 +5,7 @@ import com.qualcomm.robotcore.hardware.HardwareMap
 import dev.kingssack.volt.robot.Robot
 
 abstract class VoltOpMode<R : Robot>(robotFactory: (HardwareMap) -> R) : LinearOpMode() {
-    protected val robot : R by lazy { robotFactory(hardwareMap) }
+    protected val robot: R by lazy { robotFactory(hardwareMap) }
 
     /** Optional initialization code. */
     open fun initialize() {

--- a/Volt/src/main/kotlin/dev/kingssack/volt/opmode/autonomous/AutonomousMode.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/opmode/autonomous/AutonomousMode.kt
@@ -4,9 +4,9 @@ import com.acmerobotics.dashboard.FtcDashboard
 import com.acmerobotics.dashboard.canvas.Canvas
 import com.acmerobotics.dashboard.telemetry.TelemetryPacket
 import com.acmerobotics.roadrunner.Action
-import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
 import com.qualcomm.robotcore.hardware.HardwareMap
 import dev.kingssack.volt.core.VoltActionBuilder
+import dev.kingssack.volt.opmode.VoltOpMode
 import dev.kingssack.volt.robot.Robot
 
 /**
@@ -14,23 +14,12 @@ import dev.kingssack.volt.robot.Robot
  *
  * @property robot the robot instance
  */
-abstract class AutonomousMode<R : Robot>(private val robotFactory: (HardwareMap) -> R) :
-    LinearOpMode() {
-    protected lateinit var robot: R
-        private set
-
+abstract class AutonomousMode<R : Robot>(robotFactory: (HardwareMap) -> R) :
+    VoltOpMode<R>(robotFactory) {
     private val dash: FtcDashboard? = FtcDashboard.getInstance()
     private val canvas = Canvas()
 
-    /** Optional initialization code for the autonomous mode. */
-    open fun initialize() {
-        // Default implementation does nothing
-    }
-
-    override fun runOpMode() {
-        robot = robotFactory(hardwareMap)
-        initialize()
-        waitForStart()
+    override fun begin() {
         sequence()
     }
 

--- a/Volt/src/main/kotlin/dev/kingssack/volt/opmode/autonomous/AutonomousMode.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/opmode/autonomous/AutonomousMode.kt
@@ -12,6 +12,7 @@ import dev.kingssack.volt.robot.Robot
 /**
  * AutonomousMode is an abstract class that defines the methods for running an autonomous mode.
  *
+ * @param R the type of robot
  * @property robot the robot instance
  */
 abstract class AutonomousMode<R : Robot>(robotFactory: (HardwareMap) -> R) :
@@ -31,7 +32,7 @@ abstract class AutonomousMode<R : Robot>(robotFactory: (HardwareMap) -> R) :
         val action = VoltActionBuilder(robot).apply(block).build()
         runAction(action)
 
-        with (telemetry) {
+        with(telemetry) {
             addData("Status", "Autonomous Complete")
             update()
         }

--- a/Volt/src/main/kotlin/dev/kingssack/volt/opmode/manual/ManualMode.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/opmode/manual/ManualMode.kt
@@ -3,9 +3,9 @@ package dev.kingssack.volt.opmode.manual
 import com.acmerobotics.dashboard.FtcDashboard
 import com.acmerobotics.dashboard.telemetry.TelemetryPacket
 import com.acmerobotics.roadrunner.Action
-import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode
 import com.qualcomm.robotcore.hardware.HardwareMap
 import dev.kingssack.volt.core.VoltActionBuilder
+import dev.kingssack.volt.opmode.VoltOpMode
 import dev.kingssack.volt.robot.Robot
 import dev.kingssack.volt.util.AnalogHandler
 import dev.kingssack.volt.util.ButtonHandler
@@ -21,9 +21,9 @@ import org.firstinspires.ftc.robotcore.external.Telemetry
  * @property robot the robot instance
  */
 abstract class ManualMode<R : Robot>(
-    private val robotFactory: (HardwareMap) -> R,
+    robotFactory: (HardwareMap) -> R,
     private val params: ManualParams = ManualParams(),
-) : LinearOpMode() {
+) : VoltOpMode<R>(robotFactory) {
     /**
      * Configuration object for manual control.
      *
@@ -31,9 +31,6 @@ abstract class ManualMode<R : Robot>(
      * @property inputExp the input exponential for fine control
      */
     data class ManualParams(val deadzone: Double = 0.1, val inputExp: Double = 2.0)
-
-    protected lateinit var robot: R
-        private set
 
     private enum class InteractionType {
         RELEASE,
@@ -124,19 +121,13 @@ abstract class ManualMode<R : Robot>(
         }
     }
 
-    /** Optional initialization code can be added here. */
-    open fun initialize() {
-        // Default implementation does nothing
+    override fun initialize() {
+        super.initialize()
+        initializeInputMappings()
     }
 
-    override fun runOpMode() {
-        initializeInputMappings()
-        robot = robotFactory(hardwareMap)
-        initialize()
-        waitForStart()
-        while (opModeIsActive()) {
-            context(telemetry) { tick() }
-        }
+    override fun begin() {
+        while (opModeIsActive()) context(telemetry) { tick() }
     }
 
     private fun updateButtonHandlers() {

--- a/Volt/src/main/kotlin/dev/kingssack/volt/opmode/manual/ManualMode.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/opmode/manual/ManualMode.kt
@@ -167,10 +167,22 @@ abstract class ManualMode<R : Robot>(
         interactionHandlers[InteractionType.RELEASE]?.set(button, block)
     }
 
+    /**
+     * Checks if a button has just been tapped.
+     *
+     * @param button the button
+     * @return true if the button was just tapped, false otherwise
+     */
     protected fun isButtonTapped(button: GamepadButton): Boolean {
         return buttonHandlers[button]?.tapped() ?: false
     }
 
+    /**
+     * Registers an action sequence to be executed when a button is tapped.
+     *
+     * @param button the button
+     * @param block the action sequence to execute
+     */
     protected fun onButtonTapped(button: GamepadButton, block: VoltActionBuilder<R>.() -> Unit) {
         interactionHandlers[InteractionType.TAP]?.set(button, block)
     }

--- a/Volt/src/main/kotlin/dev/kingssack/volt/opmode/manual/SimpleManualModeWithSpeedModes.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/opmode/manual/SimpleManualModeWithSpeedModes.kt
@@ -107,7 +107,6 @@ abstract class SimpleManualModeWithSpeedModes<R : Robot>(
     context(telemetry: Telemetry)
     override fun tick() {
         telemetry.addData("Speed Mode", currentSpeedMode)
-        telemetry.addLine()
         super.tick()
     }
 }

--- a/Volt/src/main/kotlin/dev/kingssack/volt/robot/Robot.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/robot/Robot.kt
@@ -48,25 +48,25 @@ abstract class Robot(protected val hardwareMap: HardwareMap) {
         _state.value = newState
     }
 
-    private var attachments = mutableListOf<Attachment>()
+    protected var attachments = mutableListOf<Attachment>()
 
     init {
-        fun KType.isAttachmentOrNullableAttachment(): Boolean {
-            val attachment = typeOf<Attachment>()
-            val nullableAttachment = attachment.withNullability(true)
-            return this.isSubtypeOf(attachment) || this.isSubtypeOf(nullableAttachment)
-        }
-
-        this::class
-            .memberProperties
-            .filterIsInstance<KProperty1<Robot, *>>()
-            .filter { prop -> prop.returnType.isAttachmentOrNullableAttachment() }
-            .forEach { prop ->
-                val value = runCatching { prop.get(this) }.getOrNull()
-                if (value is Attachment) {
-                    attachments.add(value)
-                }
-            }
+//        fun KType.isAttachmentOrNullableAttachment(): Boolean {
+//            val attachment = typeOf<Attachment>()
+//            val nullableAttachment = attachment.withNullability(true)
+//            return this.isSubtypeOf(attachment) || this.isSubtypeOf(nullableAttachment)
+//        }
+//
+//        this::class
+//            .memberProperties
+//            .filterIsInstance<KProperty1<Robot, *>>()
+//            .filter { prop -> prop.returnType.isAttachmentOrNullableAttachment() }
+//            .forEach { prop ->
+//                val value = runCatching { prop.get(this) }.getOrNull()
+//                if (value is Attachment) {
+//                    attachments.add(value)
+//                }
+//            }
 
         setState(RobotState.Initialized)
     }

--- a/Volt/src/main/kotlin/dev/kingssack/volt/robot/Robot.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/robot/Robot.kt
@@ -14,7 +14,6 @@ import com.qualcomm.robotcore.hardware.LED
 import com.qualcomm.robotcore.hardware.NormalizedColorSensor
 import com.qualcomm.robotcore.hardware.Servo
 import dev.kingssack.volt.attachment.Attachment
-import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubtypeOf
@@ -76,110 +75,93 @@ abstract class Robot(protected val hardwareMap: HardwareMap) {
      * Helper function to create a motor property delegate.
      *
      * @param name the name of the motor
-     * @return a ReadOnlyProperty that gets the motor from the hardware map
+     * @return a Lazy that gets the motor from the hardware map
      */
-    protected fun motor(name: String): ReadOnlyProperty<Any?, DcMotor> = ReadOnlyProperty { _, _ ->
-        hardwareMap.dcMotor.get(name)
-    }
+    protected fun motor(name: String): Lazy<DcMotor> = lazy { hardwareMap.dcMotor.get(name) }
 
     /**
      * Helper function to create a servo property delegate.
      *
      * @param name the name of the servo
-     * @return a ReadOnlyProperty that gets the servo from the hardware map
+     * @return a Lazy that gets the servo from the hardware map
      */
-    protected fun servo(name: String): ReadOnlyProperty<Any?, Servo> = ReadOnlyProperty { _, _ ->
-        hardwareMap.servo.get(name)
-    }
+    protected fun servo(name: String): Lazy<Servo> = lazy { hardwareMap.servo.get(name) }
 
     /**
      * Helper function to create a continuous rotation servo property delegate.
      *
      * @param name the name of the continuous rotation servo
-     * @return a ReadOnlyProperty that gets the continuous rotation servo from the hardware map
+     * @return a Lazy that gets the continuous rotation servo from the hardware map
      */
-    protected fun crServo(name: String): ReadOnlyProperty<Any?, CRServo> =
-        ReadOnlyProperty { _, _ ->
-            hardwareMap.crservo.get(name)
-        }
+    protected fun crServo(name: String): Lazy<CRServo> = lazy { hardwareMap.crservo.get(name) }
 
     /**
      * Helper function to create a HuskyLens property delegate.
      *
      * @param name the name of the HuskyLens
-     * @return a ReadOnlyProperty that gets the HuskyLens from the hardware map
+     * @return a Lazy that gets the HuskyLens from the hardware map
      */
-    protected fun huskyLens(name: String): ReadOnlyProperty<Any?, HuskyLens> =
-        ReadOnlyProperty { _, _ ->
-            hardwareMap.get(HuskyLens::class.java, name)
-        }
+    protected fun huskyLens(name: String): Lazy<HuskyLens> = lazy {
+        hardwareMap.get(HuskyLens::class.java, name)
+    }
 
     /**
      * Helper function to create a Rev2mDistanceSensor property delegate.
      *
      * @param name the name of the Rev2mDistanceSensor
-     * @return a ReadOnlyProperty that gets the Rev2mDistanceSensor from the hardware
+     * @return a Lazy that gets the Rev2mDistanceSensor from the hardware
      */
-    protected fun distanceSensor(name: String): ReadOnlyProperty<Any?, Rev2mDistanceSensor> =
-        ReadOnlyProperty { _, _ ->
-            hardwareMap.get(Rev2mDistanceSensor::class.java, name)
-        }
+    protected fun distanceSensor(name: String): Lazy<Rev2mDistanceSensor> = lazy {
+        hardwareMap.get(Rev2mDistanceSensor::class.java, name)
+    }
 
     /**
      * Helper function to create a NormalizedColorSensor property delegate.
      *
      * @param name the name of the NormalizedColorSensor
-     * @return a ReadOnlyProperty that gets the NormalizedColorSensor from the hardware map
+     * @return a Lazy that gets the NormalizedColorSensor from the hardware map
      */
-    protected fun colorSensor(name: String): ReadOnlyProperty<Any?, NormalizedColorSensor> =
-        ReadOnlyProperty { _, _ ->
-            hardwareMap.get(NormalizedColorSensor::class.java, name)
-        }
+    protected fun colorSensor(name: String): Lazy<NormalizedColorSensor> = lazy {
+        hardwareMap.get(NormalizedColorSensor::class.java, name)
+    }
 
     /**
      * Helper function to create an IMU property delegate.
      *
      * @param name the name of the IMU
-     * @return a ReadOnlyProperty that gets the IMU from the hardware map
+     * @return a Lazy that gets the IMU from the hardware map
      */
-    protected fun imu(name: String): ReadOnlyProperty<Any?, IMU> = ReadOnlyProperty { _, _ ->
-        hardwareMap.get(IMU::class.java, name)
-    }
+    protected fun imu(name: String): Lazy<IMU> = lazy { hardwareMap.get(IMU::class.java, name) }
 
     /**
      * Helper function to create a lazy IMU property delegate.
      *
      * @param name the name of the IMU
      * @param orientation the orientation of the IMU on the robot
-     * @return a ReadOnlyProperty that gets the lazy IMU from the hardware map
+     * @return a Lazy that gets the lazy IMU from the hardware map
      */
-    protected fun lazyImu(
-        name: String,
-        orientation: RevHubOrientationOnRobot,
-    ): ReadOnlyProperty<Any?, LazyImu> = ReadOnlyProperty { _, _ ->
-        LazyHardwareMapImu(hardwareMap, name, orientation)
-    }
+    protected fun lazyImu(name: String, orientation: RevHubOrientationOnRobot): Lazy<LazyImu> =
+        lazy {
+            LazyHardwareMapImu(hardwareMap, name, orientation)
+        }
 
     /**
      * Helper function to create an LED property delegate.
      *
      * @param name the name of the LED
-     * @return a ReadOnlyProperty that gets the LED from the hardware map
+     * @return a Lazy that gets the LED from the hardware map
      */
-    protected fun led(name: String): ReadOnlyProperty<Any?, LED> = ReadOnlyProperty { _, _ ->
-        hardwareMap.led.get(name)
-    }
+    protected fun led(name: String): Lazy<LED> = lazy { hardwareMap.led.get(name) }
 
     /**
      * Helper function to create an AnalogInput property delegate.
      *
      * @param name the name of the AnalogInput
-     * @return a ReadOnlyProperty that gets the AnalogInput from the hardware map
+     * @return a Lazy that gets the AnalogInput from the hardware map
      */
-    protected fun analogInput(name: String): ReadOnlyProperty<Any?, AnalogInput> =
-        ReadOnlyProperty { _, _ ->
-            hardwareMap.analogInput.get(name)
-        }
+    protected fun analogInput(name: String): Lazy<AnalogInput> = lazy {
+        hardwareMap.analogInput.get(name)
+    }
 
     /**
      * Updates the robot.

--- a/Volt/src/main/kotlin/dev/kingssack/volt/robot/RobotWithDrivetrain.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/robot/RobotWithDrivetrain.kt
@@ -1,0 +1,16 @@
+package dev.kingssack.volt.robot
+
+import com.qualcomm.robotcore.hardware.HardwareMap
+import dev.kingssack.volt.attachment.drivetrain.Drivetrain
+
+/**
+ * A base class for robots that have a drivetrain.
+ *
+ * @param T The type of drivetrain the robot has.
+ * @param hardwareMap The hardware map of the robot.
+ * @property drivetrain The drivetrain of the robot.
+ */
+abstract class RobotWithDrivetrain<T : Drivetrain>(
+    hardwareMap: HardwareMap,
+    open val drivetrain: T,
+) : Robot(hardwareMap)

--- a/Volt/src/main/kotlin/dev/kingssack/volt/robot/RobotWithMecanumDrivetrain.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/robot/RobotWithMecanumDrivetrain.kt
@@ -1,0 +1,16 @@
+package dev.kingssack.volt.robot
+
+import com.qualcomm.robotcore.hardware.HardwareMap
+import dev.kingssack.volt.attachment.drivetrain.MecanumDrivetrain
+
+/**
+ * A base class for robots that have a mecanum drivetrain.
+ *
+ * @param T The type of mecanum drivetrain the robot has.
+ * @param hardwareMap The hardware map of the robot.
+ * @property drivetrain The mecanum drivetrain of the robot.
+ */
+abstract class RobotWithMecanumDrivetrain<T : MecanumDrivetrain>(
+    hardwareMap: HardwareMap,
+    drivetrain: T,
+) : RobotWithDrivetrain<T>(hardwareMap, drivetrain)

--- a/Volt/src/main/kotlin/dev/kingssack/volt/util/AnalogHandler.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/util/AnalogHandler.kt
@@ -3,27 +3,27 @@ package dev.kingssack.volt.util
 import kotlin.math.abs
 import kotlin.math.pow
 
-class AnalogHandler(private val deadzone: Double = 0.1, private val inputExp: Double = 2.0) {
+class AnalogHandler(private val deadzone: Float = 0.1f, private val inputExp: Float = 2.0f) {
     /**
      * Processes an input with deadzone and exponential scaling.
      *
      * @param input the input to process
      * @return the processed input
      */
-    private fun processInput(input: Double): Double {
+    private fun processInput(input: Float): Float {
         // Apply deadzone
-        if (abs(input) < deadzone) return 0.0
+        if (abs(input) < deadzone) return 0.0f
 
         // Normalize input
-        val normalizedInput = (input - deadzone) / (1 - deadzone)
+        val normalizedInput = (input - deadzone) / (1.0f - deadzone)
 
         // Apply exponential scaling for fine control
-        return normalizedInput.pow(inputExp) * if (input < 0) -1 else 1
+        return normalizedInput.pow(inputExp) * if (input < 0.0f) -1.0f else 1.0f
     }
 
-    var value: Double = 0.0
+    var value: Float = 0.0f
 
-    fun update(input: Double) {
+    fun update(input: Float) {
         value = processInput(input)
     }
 }

--- a/Volt/src/main/kotlin/dev/kingssack/volt/util/ButtonHandler.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/util/ButtonHandler.kt
@@ -33,7 +33,19 @@ class ButtonHandler(private val doubleTapThreshold: Double = 300.0) {
     }
 
     fun released(maxTimeMilliseconds: Double = 300.0): Boolean {
-        if (tapCount == 1 && !pressed && runtime.milliseconds() - lastReleaseTime <= maxTimeMilliseconds) {
+        if (
+            tapCount == 1 &&
+                !pressed &&
+                runtime.milliseconds() - lastReleaseTime <= maxTimeMilliseconds
+        ) {
+            tapCount = 0 // Reset tap count after detecting a tap
+            return true
+        }
+        return false
+    }
+
+    fun tapped(): Boolean {
+        if (tapCount == 1 && pressed) {
             tapCount = 0 // Reset tap count after detecting a tap
             return true
         }

--- a/Volt/src/main/kotlin/dev/kingssack/volt/util/ButtonHandler.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/util/ButtonHandler.kt
@@ -8,6 +8,8 @@ class ButtonHandler(private val doubleTapThreshold: Double = 300.0) {
     private var lastPressTime = 0.0
     private var lastReleaseTime = 0.0
     private var tapCount = 0
+    private var pressConsumed = false
+    private var releaseConsumed = false
 
     private val runtime: ElapsedTime = ElapsedTime()
 
@@ -17,6 +19,7 @@ class ButtonHandler(private val doubleTapThreshold: Double = 300.0) {
         if (buttonPressed) {
             if (!pressed) {
                 pressed = true
+                pressConsumed = false // Reset press flag for new press action
                 if (currentTime - lastReleaseTime < doubleTapThreshold) {
                     tapCount++
                 } else {
@@ -27,6 +30,7 @@ class ButtonHandler(private val doubleTapThreshold: Double = 300.0) {
         } else {
             if (pressed) {
                 pressed = false
+                releaseConsumed = false // Reset release flag for new release action
                 lastReleaseTime = currentTime
             }
         }
@@ -34,19 +38,19 @@ class ButtonHandler(private val doubleTapThreshold: Double = 300.0) {
 
     fun released(maxTimeMilliseconds: Double = 300.0): Boolean {
         if (
-            tapCount == 1 &&
-                !pressed &&
-                runtime.milliseconds() - lastReleaseTime <= maxTimeMilliseconds
+            !pressed &&
+                runtime.milliseconds() - lastReleaseTime <= maxTimeMilliseconds &&
+                !releaseConsumed
         ) {
-            tapCount = 0 // Reset tap count after detecting a tap
+            releaseConsumed = true
             return true
         }
         return false
     }
 
     fun tapped(): Boolean {
-        if (tapCount == 1 && pressed) {
-            tapCount = 0 // Reset tap count after detecting a tap
+        if (pressed && tapCount == 1 && !pressConsumed) {
+            pressConsumed = true
             return true
         }
         return false

--- a/Volt/src/main/kotlin/dev/kingssack/volt/util/Buttons.kt
+++ b/Volt/src/main/kotlin/dev/kingssack/volt/util/Buttons.kt
@@ -1,33 +1,53 @@
 package dev.kingssack.volt.util
 
-/**
- * Represents buttons on a gamepad.
- * Includes buttons from both gamepad1 and gamepad2.
- */
-enum class GamepadButton {
-    A1, B1, X1, Y1,
-    LEFT_BUMPER1, RIGHT_BUMPER1,
-    LEFT_STICK_BUTTON1, RIGHT_STICK_BUTTON1,
-    DPAD_UP1, DPAD_DOWN1, DPAD_LEFT1, DPAD_RIGHT1,
-    BACK1, START1, GUIDE1,
+import com.qualcomm.robotcore.hardware.Gamepad
 
-    A2, B2, X2, Y2,
-    LEFT_BUMPER2, RIGHT_BUMPER2,
-    LEFT_STICK_BUTTON2, RIGHT_STICK_BUTTON2,
-    DPAD_UP2, DPAD_DOWN2, DPAD_LEFT2, DPAD_RIGHT2,
-    BACK2, START2, GUIDE2
+/** Represents buttons on a gamepad. Includes buttons from both gamepad1 and gamepad2. */
+enum class GamepadButton(val get: (Gamepad, Gamepad) -> Boolean) {
+    A1({ g1, _ -> g1.a }),
+    B1({ g1, _ -> g1.b }),
+    X1({ g1, _ -> g1.x }),
+    Y1({ g1, _ -> g1.y }),
+    LEFT_BUMPER1({ g1, _ -> g1.left_bumper }),
+    RIGHT_BUMPER1({ g1, _ -> g1.right_bumper }),
+    LEFT_STICK_BUTTON1({ g1, _ -> g1.left_stick_button }),
+    RIGHT_STICK_BUTTON1({ g1, _ -> g1.right_stick_button }),
+    DPAD_UP1({ g1, _ -> g1.dpad_up }),
+    DPAD_DOWN1({ g1, _ -> g1.dpad_down }),
+    DPAD_LEFT1({ g1, _ -> g1.dpad_left }),
+    DPAD_RIGHT1({ g1, _ -> g1.dpad_right }),
+    BACK1({ g1, _ -> g1.back }),
+    START1({ g1, _ -> g1.start }),
+    GUIDE1({ g1, _ -> g1.guide }),
+    A2({ _, g2 -> g2.a }),
+    B2({ _, g2 -> g2.b }),
+    X2({ _, g2 -> g2.x }),
+    Y2({ _, g2 -> g2.y }),
+    LEFT_BUMPER2({ _, g2 -> g2.left_bumper }),
+    RIGHT_BUMPER2({ _, g2 -> g2.right_bumper }),
+    LEFT_STICK_BUTTON2({ _, g2 -> g2.left_stick_button }),
+    RIGHT_STICK_BUTTON2({ _, g2 -> g2.right_stick_button }),
+    DPAD_UP2({ _, g2 -> g2.dpad_up }),
+    DPAD_DOWN2({ _, g2 -> g2.dpad_down }),
+    DPAD_LEFT2({ _, g2 -> g2.dpad_left }),
+    DPAD_RIGHT2({ _, g2 -> g2.dpad_right }),
+    BACK2({ _, g2 -> g2.back }),
+    START2({ _, g2 -> g2.start }),
+    GUIDE2({ _, g2 -> g2.guide }),
 }
 
-/**
- * Represents analog inputs on a gamepad.
- * Includes inputs from both gamepad1 and gamepad2.
- */
-enum class GamepadAnalogInput {
-    LEFT_STICK_X1, LEFT_STICK_Y1,
-    RIGHT_STICK_X1, RIGHT_STICK_Y1,
-    LEFT_TRIGGER1, RIGHT_TRIGGER1,
-
-    LEFT_STICK_X2, LEFT_STICK_Y2,
-    RIGHT_STICK_X2, RIGHT_STICK_Y2,
-    LEFT_TRIGGER2, RIGHT_TRIGGER2
+/** Represents analog inputs on a gamepad. Includes inputs from both gamepad1 and gamepad2. */
+enum class GamepadAnalogInput(val get: (Gamepad, Gamepad) -> Float) {
+    LEFT_STICK_X1({ g1, _ -> g1.left_stick_x }),
+    LEFT_STICK_Y1({ g1, _ -> g1.left_stick_y }),
+    RIGHT_STICK_X1({ g1, _ -> g1.right_stick_x }),
+    RIGHT_STICK_Y1({ g1, _ -> g1.right_stick_y }),
+    LEFT_TRIGGER1({ g1, _ -> g1.left_trigger }),
+    RIGHT_TRIGGER1({ g1, _ -> g1.right_trigger }),
+    LEFT_STICK_X2({ _, g2 -> g2.left_stick_x }),
+    LEFT_STICK_Y2({ _, g2 -> g2.left_stick_y }),
+    RIGHT_STICK_X2({ _, g2 -> g2.right_stick_x }),
+    RIGHT_STICK_Y2({ _, g2 -> g2.right_stick_y }),
+    LEFT_TRIGGER2({ _, g2 -> g2.left_trigger }),
+    RIGHT_TRIGGER2({ _, g2 -> g2.right_trigger }),
 }

--- a/docs/src/content/docs/guides/01-robots.mdx
+++ b/docs/src/content/docs/guides/01-robots.mdx
@@ -9,9 +9,9 @@ The `Robot` class is the heart of your robot's code. It serves as a centralized 
 
 ## Guide
 
-You should create a new `Robot` class for each type of physical robot you've built.
+This guide will walk you through the process of setting up your own `Robot`.
 
-This guide will walk you through the process of setting up your own `Robot` class.
+You should create a new `Robot` class for each type of physical robot you've built.
 
 ### 1. Create Your `Robot` Class
 

--- a/docs/src/content/docs/guides/02-attachments.mdx
+++ b/docs/src/content/docs/guides/02-attachments.mdx
@@ -11,6 +11,8 @@ An `Attachment` can be shared by multiple `Robot`s.
 
 ## Guide
 
+This guide will walk you through the process of setting up your own `Attachment`.
+
 There should be one `Attachment` per "interaction" your `Robot` can perform.
 
 :::caution

--- a/docs/src/content/docs/guides/03-autonomous-mode.mdx
+++ b/docs/src/content/docs/guides/03-autonomous-mode.mdx
@@ -9,7 +9,7 @@ An `AutonomousMode` is a pre-programmed sequence of actions that your `Robot` wi
 
 ## Guide
 
-An `AutonomousMode` defines a sequence of `Action`s for your `Robot` to execute.
+This guide will walk you through the process of setting up your own `AutonomousMode`.
 
 ### 1. Create Your `AutonomousMode` Class
 

--- a/docs/src/content/docs/guides/04-manual-mode.mdx
+++ b/docs/src/content/docs/guides/04-manual-mode.mdx
@@ -9,6 +9,8 @@ A `ManualMode` is a teleoperated mode that allows you to control your `Robot` us
 
 ## Guide
 
+This guide will walk you through the process of setting up your own `ManualMode`.
+
 A `ManualMode` links inputs (buttons, analog sticks, etc.) to `Action`s from your `Robot`.
 
 ### 1. Create Your `ManualMode` Class


### PR DESCRIPTION
Summary
- Add VoltOpMode and extend Volt features (Drivetrain as Attachment, 
MecanumDrivetrains, manual analog actions, onAnalogValueChanged, allow tap and release together) 
- Change hardware delegates from ReadOnlyProperty to Lazy and allow manual attachment registration 
- Fixes: strafeTicksToInches, modified state timing, right trigger launch, allow tap+release 
- - Introduce Storage and new robot profiles/components (Penguin -> 
- rwhal refactor, JonesPP/JonesRR, GabePP/GabeRR)
- Refactors and style updates (increment version number, add space, 
- clean docs)